### PR TITLE
Improve security - Add password support for switchbots

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,21 @@
 # pySwitchbot [![Build Status](https://travis-ci.org/Danielhiversen/pySwitchbot.svg?branch=master)](https://travis-ci.org/Danielhiversen/pySwitchbot)
-Library to control Switchbot
+Library to control Switchbot IoT devices https://www.switch-bot.com/bot
 
-[Buy me a coffee :)](http://paypal.me/dahoiv)
+This project is an initial fork from https://github.com/Danielhiversen/pySwitchbot with some major improvements targeted:
+
+- [x] Improved error handling and retry logic when trying to connect to switchbots
+- [x] Correct [Bluepy](https://github.com/IanHarvey/bluepy) API usage
+- [x] Add password support (must set a password first in the Switchbot iOS/Android app)
+- [x] Get current battery percentage and firmware version
+- [ ] Get and set long press time settings
+- [ ] Allow setting the password in an API
+- [ ] Manage timers etc
+- [ ] Switch between press and switch modes
+
+The goal is to make this component work with [HomeAssistant](https://www.home-assistant.io/integrations/switchbot/) to give more flexibility to users of Switchbots without needing a SwitchBot hub.
+
+Hopefully this project will address some of the shortcomings in the official Switchbot [open API](https://github.com/OpenWonderLabs/python-host).
+
+Please raise any feature requests as issues. 
+
+[Buy me a coffee :)](https://paypal.me/nemccarthy)

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -7,7 +7,7 @@ import logging
 import bluepy
 
 DEFAULT_RETRY_COUNT = 3
-DEFAULT_RETRY_TIMEOUT = .05
+DEFAULT_RETRY_TIMEOUT = .1
 
 UUID = "cba20d00-224d-11e6-9fb8-0002a5d5c51b"
 HANDLE = "cba20002-224d-11e6-9fb8-0002a5d5c51b"

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -25,6 +25,7 @@ PRESS_KEY_SUFFIX = "00"
 
 _LOGGER = logging.getLogger(__name__)
 
+
 class Switchbot:
     """Representation of a Switchbot."""
 
@@ -72,7 +73,8 @@ class Switchbot:
             _LOGGER.info("Successfully sent command to Switchbot (MAC: %s).", self._mac)
         return write_result
 
-    def _passwordcrc(self, password) -> str:
+    @staticmethod
+    def _passwordcrc(password) -> str:
         if password is None or password == "":
             return None
         return '%x' % (binascii.crc32(password.encode('ascii')) & 0xffffffff)

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -4,6 +4,7 @@ import binascii
 import logging
 
 import bluepy
+import time
 
 UUID = "cba20d00-224d-11e6-9fb8-0002a5d5c51b"
 HANDLE = "cba20002-224d-11e6-9fb8-0002a5d5c51b"
@@ -22,49 +23,67 @@ class Switchbot:
         self._mac = mac
         self._device = None
 
-    def _connect(self) -> bool:
+    def _connect(self):
+        if self._device is None:
+            try:
+                _LOGGER.debug("Connecting to Switchbot...")
+                self._device = bluepy.btle.Peripheral(self._mac,
+                                                      bluepy.btle.ADDR_TYPE_RANDOM)
+                _LOGGER.debug("Connected to Switchbot.")
+            except bluepy.btle.BTLEException:
+                _LOGGER.warning("Failed connecting to Switchbot.", exc_info=True)
+                self._device = None
+                raise
+
+    def _disconnect(self):
         if self._device is not None:
             _LOGGER.debug("Disconnecting")
             try:
                 self._device.disconnect()
             except bluepy.btle.BTLEException:
-                pass
-        try:
-            _LOGGER.debug("Connecting")
-            self._device = bluepy.btle.Peripheral(self._mac,
-                                                  bluepy.btle.ADDR_TYPE_RANDOM)
-        except bluepy.btle.BTLEException:
-            _LOGGER.warning("Failed to connect to Switchbot", exc_info=True)
-            return False
-        return True
+                _LOGGER.warning("Error disconnecting from Switchbot.", exc_info=True)
+            finally:
+                self._device = None
 
-    def _sendpacket(self, key, retry=2) -> bool:
-        if self._device is None and not self._connect():
-            _LOGGER.error("Can not connect to switchbot.")
-            return False
+    def _writekey(self, key) -> bool:
+        _LOGGER.debug("Prepare to send")
+        hand_service = self._device.getServiceByUUID(UUID)
+        hand = hand_service.getCharacteristics(HANDLE)[0]
+        _LOGGER.debug("Sending command, %s", key)
+        write_result = hand.write(binascii.a2b_hex(key), withResponse=True)
+        if not write_result:
+            _LOGGER.error("Sent command but didn't get a response from Switchbot confirming command was sent. "
+                          "Please check the Switchbot.")
+        else:
+            _LOGGER.debug("Successfully sent command to Switchbot.")
+        return write_result
 
+    def _sendcommand(self, key, retry=3) -> bool:
+        send_success = False
         try:
-            _LOGGER.debug("Prepare to send")
-            hand_service = self._device.getServiceByUUID(UUID)
-            hand = hand_service.getCharacteristics(HANDLE)[0]
-            _LOGGER.debug("Sending command, %s", key)
-            hand.write(binascii.a2b_hex(key))
+            self._connect()
+            send_success = self._writekey(key)
         except bluepy.btle.BTLEException:
-            if retry < 1 or not self._connect():
-                _LOGGER.error("Can not connect to switchbot.", exc_info=True)
-                return False
-            _LOGGER.warning("Can not connect to switchbot. Retrying")
-            return self._sendpacket(key, retry-1)
-        return True
+            _LOGGER.warning("Error talking to Switchbot.", exc_info=True)
+        finally:
+            self._disconnect()
+        if not send_success:
+            if retry < 1:
+                _LOGGER.error("Switchbot communication failed. Stopping trying.", exc_info=True)
+            else:
+                _LOGGER.warning("Cannot connect to Switchbot. Retrying (remaining: %d)...", retry)
+                time.sleep(.25)
+                return self._sendcommand(key, retry - 1)
+        return send_success
 
     def turn_on(self) -> None:
         """Turn device on."""
-        return self._sendpacket(ON_KEY)
+        return self._sendcommand(ON_KEY)
 
     def turn_off(self) -> None:
         """Turn device off."""
-        return self._sendpacket(OFF_KEY)
+        return self._sendcommand(OFF_KEY)
 
     def press(self) -> None:
         """Press command to device."""
-        return self._sendpacket(PRESS_KEY)
+        return self._sendcommand(PRESS_KEY)

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -1,10 +1,10 @@
 """Library to handle connection with Switchbot"""
+import time
 
 import binascii
 import logging
 
 import bluepy
-import time
 
 UUID = "cba20d00-224d-11e6-9fb8-0002a5d5c51b"
 HANDLE = "cba20002-224d-11e6-9fb8-0002a5d5c51b"


### PR DESCRIPTION
This PR builds on previous improvements to allow for password support.

The password can be setup in the switchbot application on iPhone or Android by;

1. Click the settings icon next to the switchbot
2. Click Password, Mode settings
3. Click on password and set a password using ASCII characters 

Then pass the password into pySwitchbot as a string. 