### PR TITLE
Add Class to discover all switchbots, all curtain bots or all bot (woHand)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name = 'PySwitchbot',
     packages = ['switchbot'],
     install_requires=['bluepy'],
-    version = '0.10.1',
+    version = '0.10.2',
     description = 'A library to communicate with Switchbot',
     author='Daniel Hjelseth Hoyer',
     url='https://github.com/Danielhiversen/pySwitchbot/',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name = 'PySwitchbot',
     packages = ['switchbot'],
     install_requires=['bluepy'],
-    version = '0.10.2',
+    version = '0.11.0',
     description = 'A library to communicate with Switchbot',
     author='Daniel Hjelseth Hoyer',
     url='https://github.com/Danielhiversen/pySwitchbot/',

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -269,14 +269,14 @@ class SwitchbotDevice:
         send_success = False
         command = self._commandkey(key)
         _LOGGER.debug("Sending command to switchbot %s", command)
-        try:
-            with CONNECT_LOCK:
+        with CONNECT_LOCK:
+            try:
                 self._connect()
                 send_success = self._writekey(command)
-        except bluepy.btle.BTLEException:
-            _LOGGER.warning("Error talking to Switchbot", exc_info=True)
-        finally:
-            self._disconnect()
+            except bluepy.btle.BTLEException:
+                _LOGGER.warning("Error talking to Switchbot", exc_info=True)
+            finally:
+                self._disconnect()
         if send_success:
             return True
         if retry < 1:

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -272,7 +272,7 @@ class SwitchbotDevice:
 
     def get_device_data(self, mac) -> dict:
         """Return data for specific device."""
-        if not self._switchbot_device_data:
+        if not self._all_services_data:
             self.discover()
 
         for item in self._all_services_data:
@@ -292,9 +292,9 @@ class Switchbot(SwitchbotDevice):
 
     def update(self, scan_timeout=5) -> None:
         """Update mode, battery percent and state of device."""
-        _scan_btle_adv = self.discover(scan_timeout=scan_timeout)
+        _success = self.discover(scan_timeout=scan_timeout)
 
-        if _scan_btle_adv:
+        if _success:
             self.get_device_data(self._mac)
 
     def turn_on(self) -> bool:
@@ -365,9 +365,9 @@ class SwitchbotCurtain(SwitchbotDevice):
 
     def update(self, scan_timeout=5) -> None:
         """Update position, battery percent and light level of device."""
-        _scan_btle_adv = self.discover(scan_timeout=scan_timeout)
+        _success = self.discover(scan_timeout=scan_timeout)
 
-        if _scan_btle_adv:
+        if _success:
             self.get_device_data(self._mac)
 
     def get_position(self) -> int:

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -45,9 +45,6 @@ class SwitchbotDevices:
         returns after the given timeout period in seconds."""
         devices = None
 
-        waiting_time = self._time_between_update_command - time.time()
-        if waiting_time > 0:
-            time.sleep(waiting_time)
         try:
             devices = bluepy.btle.Scanner().scan(scan_timeout)
 

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -107,6 +107,8 @@ class SwitchbotDevices:
 
                 bot_sensors[item]["battery_percent"] = _sensor_data[2] & 0b01111111
 
+        return bot_sensors
+
     def all_curtains(self) -> dict:
         """Return all bots with their data."""
         self.discover()
@@ -118,12 +120,17 @@ class SwitchbotDevices:
                 _sensor_data = self._services_data[item]["16b Service Data"]
                 _sensor_data = binascii.unhexlify(_sensor_data.encode())
 
-                curtain_sensors[item]['calibrated'] = _sensor_data[1] & 0b01000000
-                curtain_sensors[item]['battery_percent'] = _sensor_data[2] & 0b01111111
+                curtain_sensors[item]["calibrated"] = _sensor_data[1] & 0b01000000
+                curtain_sensors[item]["battery_percent"] = _sensor_data[2] & 0b01111111
                 _position = max(min(_sensor_data[3] & 0b01111111, 100), 0)
-                curtain_sensors[item]['pos'] = (100 - _position) if self._reverse else _position
-                curtain_sensors[item]['light_level'] = (_sensor_data[4] >> 4) & 0b00001111  # light sensor level (1-10)
+                curtain_sensors[item]["pos"] = (
+                    (100 - _position) if self._reverse else _position
+                )
+                curtain_sensors[item]["light_level"] = (
+                    _sensor_data[4] >> 4
+                ) & 0b00001111  # light sensor level (1-10)
 
+        return curtain_sensors
 
 
 class SwitchbotDevice:

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -289,13 +289,12 @@ class Switchbot(SwitchbotDevice):
         """Switchbot Bot/WoHand constructor."""
         super().__init__(*args, **kwargs)
         self._inverse = kwargs.pop("inverse_mode", False)
-        self._switchbot_device_data = {}
 
     def update(self, scan_timeout=5) -> None:
         """Update mode, battery percent and state of device."""
-        self._switchbot_device_data = self.discover(scan_timeout=scan_timeout)
+        _success = self.discover(scan_timeout=scan_timeout)
 
-        if self._switchbot_device_data:
+        if _success:
             self.get_device_data(self._mac)
 
     def turn_on(self) -> bool:
@@ -345,7 +344,6 @@ class SwitchbotCurtain(SwitchbotDevice):
 
         super().__init__(*args, **kwargs)
         self._reverse = kwargs.pop("reverse_mode", True)
-        self._switchbot_device_data = {}
 
     def open(self) -> bool:
         """Send open command."""
@@ -367,9 +365,9 @@ class SwitchbotCurtain(SwitchbotDevice):
 
     def update(self, scan_timeout=5) -> None:
         """Update position, battery percent and light level of device."""
-        self._switchbot_device_data = self.discover(scan_timeout=scan_timeout)
+        _success = self.discover(scan_timeout=scan_timeout)
 
-        if self._switchbot_device_data:
+        if _success:
             self.get_device_data(self._mac)
 
     def get_position(self) -> int:
@@ -401,7 +399,8 @@ class SwitchbotCurtain(SwitchbotDevice):
 class SwitchbotDevices(Switchbot, SwitchbotCurtain):
     """Superclass for all switchbot device types."""
 
-    def __init__(self, mac, *args, **kwargs) -> None:
+    def __init__(self, *args, **kwargs) -> None:
         """HA coordinator switchbot class constructor."""
         super().__init__(*args, **kwargs)
-        self._mac = mac
+        Switchbot().__init__(self)
+        SwitchbotCurtain().__init__(self)

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -120,7 +120,7 @@ class SwitchbotDevices:
                 _sensor_data = self._services_data[item]["16b Service Data"]
                 _sensor_data = binascii.unhexlify(_sensor_data.encode())
 
-                curtain_sensors[item]["calibrated"] = _sensor_data[1] & 0b01000000
+                curtain_sensors[item]["calibrated"] = bool(_sensor_data[1] & 0b01000000)
                 curtain_sensors[item]["battery_percent"] = _sensor_data[2] & 0b01111111
                 _position = max(min(_sensor_data[3] & 0b01111111, 100), 0)
                 curtain_sensors[item]["pos"] = (

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -186,8 +186,9 @@ class SwitchbotDevice:
         try:
             devices = bluepy.btle.Scanner().scan(scan_timeout)
 
-        except bluepy.btle.BTLEManagementError:
-            _LOGGER.warning("Error scanning for Switchbot devices", exc_info=True)
+        except bluepy.btle.BTLEManagementError as err:
+            _LOGGER.error("Error scanning for switchbot devices", exc_info=True)
+            raise bluepy.btle.BTLEManagementError(err) from err
 
         if devices is None:
             if retry < 1:
@@ -292,7 +293,12 @@ class Switchbot(SwitchbotDevice):
 
     def update(self, scan_timeout=5) -> None:
         """Update mode, battery percent and state of device."""
-        self.discover(scan_timeout=scan_timeout)
+        try:
+            self.discover(scan_timeout=scan_timeout)
+        except bluepy.btle.BTLEManagementError as err:
+            _LOGGER.error("Error fetching initial data", exc_info=True)
+            raise bluepy.btle.BTLEManagementError(err) from err
+
         self.get_device_data(self._mac)
 
     def turn_on(self) -> bool:
@@ -363,7 +369,12 @@ class SwitchbotCurtain(SwitchbotDevice):
 
     def update(self, scan_timeout=5) -> None:
         """Update position, battery percent and light level of device."""
-        self.discover(scan_timeout=scan_timeout)
+        try:
+            self.discover(scan_timeout=scan_timeout)
+        except bluepy.btle.BTLEManagementError as err:
+            _LOGGER.error("Error fetching initial data", exc_info=True)
+            raise bluepy.btle.BTLEManagementError(err) from err
+
         self.get_device_data(self._mac)
 
     def get_position(self) -> int:

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -186,9 +186,8 @@ class SwitchbotDevice:
         try:
             devices = bluepy.btle.Scanner().scan(scan_timeout)
 
-        except bluepy.btle.BTLEManagementError as err:
+        except bluepy.btle.BTLEManagementError:
             _LOGGER.error("Error scanning for switchbot devices", exc_info=True)
-            raise bluepy.btle.BTLEManagementError from err
 
         if devices is None:
             if retry < 1:
@@ -293,13 +292,10 @@ class Switchbot(SwitchbotDevice):
 
     def update(self, scan_timeout=5) -> None:
         """Update mode, battery percent and state of device."""
-        try:
-            self.discover(scan_timeout=scan_timeout)
-        except bluepy.btle.BTLEManagementError as err:
-            _LOGGER.error("Error fetching initial data", exc_info=True)
-            raise bluepy.btle.BTLEManagementError from err
+        _scan_btle_adv = self.discover(scan_timeout=scan_timeout)
 
-        self.get_device_data(self._mac)
+        if _scan_btle_adv:
+            self.get_device_data(self._mac)
 
     def turn_on(self) -> bool:
         """Turn device on."""
@@ -369,13 +365,10 @@ class SwitchbotCurtain(SwitchbotDevice):
 
     def update(self, scan_timeout=5) -> None:
         """Update position, battery percent and light level of device."""
-        try:
-            self.discover(scan_timeout=scan_timeout)
-        except bluepy.btle.BTLEManagementError as err:
-            _LOGGER.error("Error fetching initial data", exc_info=True)
-            raise bluepy.btle.BTLEManagementError from err
+        _scan_btle_adv = self.discover(scan_timeout=scan_timeout)
 
-        self.get_device_data(self._mac)
+        if _scan_btle_adv:
+            self.get_device_data(self._mac)
 
     def get_position(self) -> int:
         """Return cached position (0-100) of Curtain."""

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -183,34 +183,26 @@ class GetSwitchbotDevices:
         if not self._all_services_data:
             self.discover()
 
-        if self._all_services_data:
+        _bot_devices = {}
 
-            _bot_devices = {}
+        for item in self._all_services_data:
+            if self._all_services_data[item]["model"] == "H":
+                _bot_devices[item] = self._all_services_data[item]
 
-            for item in self._all_services_data:
-                if self._all_services_data[item]["model"] == "H":
-                    _bot_devices[item] = self._all_services_data[item]
-
-            return _bot_devices
-
-        return None
+        return _bot_devices
 
     def get_device_data(self, mac) -> dict | None:
         """Return data for specific device."""
         if not self._all_services_data:
             self.discover()
 
-        if self._all_services_data:
+        _switchbot_data = {}
 
-            _switchbot_data = {}
+        for item in self._all_services_data:
+            if self._all_services_data[item]["mac_address"] == mac:
+                _switchbot_data = self._all_services_data[item]
 
-            for item in self._all_services_data:
-                if self._all_services_data[item]["mac_address"] == mac:
-                    _switchbot_data = self._all_services_data[item]
-
-            return _switchbot_data
-
-        return None
+        return _switchbot_data
 
 
 class SwitchbotDevice:

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -188,7 +188,7 @@ class SwitchbotDevice:
 
         except bluepy.btle.BTLEManagementError as err:
             _LOGGER.error("Error scanning for switchbot devices", exc_info=True)
-            raise bluepy.btle.BTLEManagementError(err) from err
+            raise bluepy.btle.BTLEManagementError from err
 
         if devices is None:
             if retry < 1:
@@ -297,7 +297,7 @@ class Switchbot(SwitchbotDevice):
             self.discover(scan_timeout=scan_timeout)
         except bluepy.btle.BTLEManagementError as err:
             _LOGGER.error("Error fetching initial data", exc_info=True)
-            raise bluepy.btle.BTLEManagementError(err) from err
+            raise bluepy.btle.BTLEManagementError from err
 
         self.get_device_data(self._mac)
 
@@ -373,7 +373,7 @@ class SwitchbotCurtain(SwitchbotDevice):
             self.discover(scan_timeout=scan_timeout)
         except bluepy.btle.BTLEManagementError as err:
             _LOGGER.error("Error fetching initial data", exc_info=True)
-            raise bluepy.btle.BTLEManagementError(err) from err
+            raise bluepy.btle.BTLEManagementError from err
 
         self.get_device_data(self._mac)
 

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -94,6 +94,14 @@ class SwitchbotDevices:
                             self._services_data[dev_id]["serviceData"][
                                 "modelName"
                             ] = "WoCurtain"
+                        if _model == "T":
+                            self._services_data[dev_id][
+                                "serviceData"
+                            ] = self._process_wocurtain(value[4:])
+                            self._services_data[dev_id]["serviceData"]["model"] = _model
+                            self._services_data[dev_id]["serviceData"][
+                                "modelName"
+                            ] = "WoSensorTH"
                     else:
                         self._services_data[dev_id][desc] = value
 
@@ -134,6 +142,27 @@ class SwitchbotDevices:
         ) & 0b00001111  # light sensor level (1-10)
 
         return _curtain_data
+
+    # pylint: disable=R0201
+    def _process_wosensorth(self, data) -> dict:
+        """Process woSensorTH/Temp sensor services data."""
+        _wosensorth_data = {}
+
+        _sensor_data = binascii.unhexlify(data.encode())
+
+        _temp_sign = _sensor_data[4] & 0b10000000
+        _temp_c = _temp_sign * ((_sensor_data[4] & 0b01111111) + (_sensor_data[3] / 10))
+        _temp_f = (_temp_c * 9 / 5) + 32
+        _temp_f = (_temp_f * 10) / 10
+
+        _wosensorth_data["temp"]["c"] = _temp_c
+        _wosensorth_data["temp"]["f"] = _temp_f
+
+        _wosensorth_data["fahrenheit"] = bool(_sensor_data[5] & 0b10000000)
+        _wosensorth_data["humidity"] = _sensor_data[5] & 0b01111111
+        _wosensorth_data["battery"] = _sensor_data[2] & 0b01111111
+
+        return _wosensorth_data
 
     def get_curtains(self) -> dict:
         """Return all WoCurtain/Curtains devices with services data."""

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -287,8 +287,9 @@ class Switchbot(SwitchbotDevice):
 
     def __init__(self, *args, **kwargs) -> None:
         """Switchbot Bot/WoHand constructor."""
-        self._inverse = kwargs.pop("inverse_mode", False)
         super().__init__(*args, **kwargs)
+        self._inverse = kwargs.pop("inverse_mode", False)
+        self._switchbot_device_data = {}
 
     def update(self, scan_timeout=5) -> None:
         """Update mode, battery percent and state of device."""
@@ -342,8 +343,9 @@ class SwitchbotCurtain(SwitchbotDevice):
         # and position = 100 equals open. The parameter is default set to True so that
         # the definition of position is the same as in Home Assistant.
 
-        self._reverse = kwargs.pop("reverse_mode", True)
         super().__init__(*args, **kwargs)
+        self._reverse = kwargs.pop("reverse_mode", True)
+        self._switchbot_device_data = {}
 
     def open(self) -> bool:
         """Send open command."""

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -277,7 +277,7 @@ class SwitchbotDevice:
 
         for item in self._all_services_data:
             if self._all_services_data[item]["mac_address"] == mac:
-                self._switchbot_device_data[item] = self._all_services_data[item]
+                self._switchbot_device_data = self._all_services_data[item]
 
         return self._switchbot_device_data
 

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -110,8 +110,8 @@ class SwitchbotDevices:
             _sensor_data[1] & 0b10000000
         )  # 128 switch or 0 press
 
-        _is_on = bool(_sensor_data[1] & 0b01000000)  # 64 on or 0 for off
-        if bool(_sensor_data[1] & 0b10000000):
+        # 64 on or 0 for off
+        if not bool(_sensor_data[1] & 0b10000000):
             bot_sensors["state"] = False
         else:
             bot_sensors["state"] = bool(_sensor_data[1] & 0b01000000)

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -39,8 +39,6 @@ class SwitchbotDevices:
         )
         self._services_data = {}
         self._reverse = kwargs.pop("reverse_mode", True)
-        self._invert_switch = kwargs.pop("invert_switch", False)
-        self._mac = kwargs.pop("mac", False)
 
     def discover(self, retry=DEFAULT_RETRY_COUNT, scan_timeout=5) -> dict:
         """Find switchbot devices and their advertisement data,
@@ -107,6 +105,7 @@ class SwitchbotDevices:
 
         return self._services_data
 
+    # pylint: disable=R0201
     def _process_wohand(self, data) -> dict:
         """Process woHand/Bot services data."""
         _bot_data = {}
@@ -117,11 +116,11 @@ class SwitchbotDevices:
         )  # 128 switch or 0 press.
 
         # 64 off or 0 for on, if not inversed in app.
-        if self._invert_switch:
-            _bot_data["isOn"] = bool(_sensor_data[1] & 0b01000000)
+        if _bot_data["switchMode"]:
+            _bot_data["isOn"] = not bool(_sensor_data[1] & 0b01000000)
 
         else:
-            _bot_data["isOn"] = not bool(_sensor_data[1] & 0b01000000)
+            _bot_data["isOn"] = False
 
         _bot_data["battery"] = _sensor_data[2] & 0b01111111
 
@@ -184,12 +183,12 @@ class SwitchbotDevices:
 
         return _bot_devices
 
-    def get_device(self) -> dict:
+    def get_device(self, mac) -> dict:
         """Return data for specific device."""
         _switchbot_device = {}
 
         for item in self._services_data:
-            if self._services_data[item]["mac_address"] == self._mac:
+            if self._services_data[item]["mac_address"] == mac:
                 _switchbot_device[item] = self._services_data[item]
 
         return _switchbot_device

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -293,9 +293,9 @@ class Switchbot(SwitchbotDevice):
 
     def update(self, scan_timeout=5) -> None:
         """Update mode, battery percent and state of device."""
-        _success = self.discover(scan_timeout=scan_timeout)
+        self._switchbot_device_data = self.discover(scan_timeout=scan_timeout)
 
-        if _success:
+        if self._switchbot_device_data:
             self.get_device_data(self._mac)
 
     def turn_on(self) -> bool:
@@ -367,9 +367,9 @@ class SwitchbotCurtain(SwitchbotDevice):
 
     def update(self, scan_timeout=5) -> None:
         """Update position, battery percent and light level of device."""
-        _success = self.discover(scan_timeout=scan_timeout)
+        self._switchbot_device_data = self.discover(scan_timeout=scan_timeout)
 
-        if _success:
+        if self._switchbot_device_data:
             self.get_device_data(self._mac)
 
     def get_position(self) -> int:

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -247,7 +247,7 @@ class SwitchbotDevice:
     def get_battery_percent(self) -> int:
         """Return device battery level in percent."""
         if not self._switchbot_device_data:
-            self.get_device(self._mac)
+            self.get_device_data(self._mac)
         return self._switchbot_device_data["data"]["battery"]
 
     def get_curtains(self) -> dict:
@@ -270,8 +270,11 @@ class SwitchbotDevice:
 
         return _bot_devices
 
-    def get_device(self, mac) -> dict:
+    def get_device_data(self, mac) -> dict:
         """Return data for specific device."""
+        if not self._switchbot_device_data:
+            self.discover()
+
         for item in self._all_services_data:
             if self._all_services_data[item]["mac_address"] == mac:
                 self._switchbot_device_data[item] = self._all_services_data[item]
@@ -290,7 +293,7 @@ class Switchbot(SwitchbotDevice):
     def update(self, scan_timeout=5) -> None:
         """Update mode, battery percent and state of device."""
         self.discover(scan_timeout=scan_timeout)
-        self.get_device(self._mac)
+        self.get_device_data(self._mac)
 
     def turn_on(self) -> bool:
         """Turn device on."""
@@ -361,21 +364,21 @@ class SwitchbotCurtain(SwitchbotDevice):
     def update(self, scan_timeout=5) -> None:
         """Update position, battery percent and light level of device."""
         self.discover(scan_timeout=scan_timeout)
-        self.get_device(self._mac)
+        self.get_device_data(self._mac)
 
     def get_position(self) -> int:
         """Return cached position (0-100) of Curtain."""
         # To get actual position call update() first.
         if not self._switchbot_device_data:
             self.update()
-        return self._switchbot_device_data["position"]
+        return self._switchbot_device_data["data"]["position"]
 
     def get_light_level(self) -> int:
         """Return cached light level."""
         # To get actual light level call update() first.
         if not self._switchbot_device_data:
             self.update()
-        return self._switchbot_device_data["lightLevel"]
+        return self._switchbot_device_data["data"]["lightLevel"]
 
     def is_reversed(self) -> bool:
         """Return True if the curtain open from left to right."""
@@ -386,7 +389,7 @@ class SwitchbotCurtain(SwitchbotDevice):
         # To get actual light level call update() first.
         if not self._switchbot_device_data:
             self.update()
-        return self._switchbot_device_data["calibration"]
+        return self._switchbot_device_data["data"]["calibration"]
 
 
 class SwitchbotDevices(Switchbot, SwitchbotCurtain):

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -173,7 +173,7 @@ class GetSwitchbotDevices:
         _curtain_devices = {}
 
         for item in self._all_services_data:
-            if self._all_services_data[item]["data"]["model"] == "c":
+            if self._all_services_data[item]["model"] == "c":
                 _curtain_devices[item] = self._all_services_data[item]
 
         return _curtain_devices
@@ -188,7 +188,7 @@ class GetSwitchbotDevices:
             _bot_devices = {}
 
             for item in self._all_services_data:
-                if self._all_services_data[item]["data"]["model"] == "H":
+                if self._all_services_data[item]["model"] == "H":
                     _bot_devices[item] = self._all_services_data[item]
 
             return _bot_devices

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -71,14 +71,14 @@ class SwitchbotDevices:
             if dev.getValueText(7) == UUID:
                 dev_id = dev.addr.replace(":", "")
                 self._services_data[dev_id] = {}
-                self._services_data[dev_id]["mac_address"] = dev.addr
-                self._services_data[dev_id]["rssi"] = dev.rssi
+                self._services_data[dev_id]['mac_address'] = dev.addr
+                self._services_data[dev_id]['rssi'] = dev.rssi
                 for (adtype, desc, value) in dev.getScanData():
                     if adtype == 22:
                         _model = binascii.unhexlify(value[4:6]).decode()
                         if _model == "H":
                             self._services_data[dev_id][
-                                "serviceData"
+                                'serviceData'
                             ] = self._process_wohand(value[4:])
                             self._services_data[dev_id]['serviceData'][
                                 'model'
@@ -111,7 +111,7 @@ class SwitchbotDevices:
         )  # 128 switch or 0 press
 
         # 64 on or 0 for off
-        if not bool(_sensor_data[1] & 0b10000000):
+        if bot_sensors["modeSwitch"]:
             bot_sensors["state"] = False
         else:
             bot_sensors["state"] = bool(_sensor_data[1] & 0b01000000)
@@ -138,11 +138,23 @@ class SwitchbotDevices:
 
     def get_curtains(self) -> dict:
         """Return all WoCurtain/Curtains devices with services data."""
-        _curtains = [item for item in self._services_data if item['model'] == 'c']
+        _curtain_devices = {}
+
+        for item in self._services_data:
+            if item['serviceData']['model'] == 'c':
+                _curtain_devices[item] = item
+
+        return _curtain_devices
 
     def get_bots(self) -> dict:
         """Return all WoHand/Bot devices with services data."""
-        _bots = [item for item in self._services_data if item['model'] == 'H']
+        _bot_devices = {}
+
+        for item in self._services_data:
+            if item['serviceData']['model'] == 'H':
+                _bot_devices[item] = item
+
+        return _bot_devices
 
 class SwitchbotDevice:
     # pylint: disable=too-many-instance-attributes

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -181,7 +181,7 @@ class SwitchbotDevice:
         time.sleep(DEFAULT_RETRY_TIMEOUT)
         return self._sendcommand(key, retry - 1)
 
-    def discover(self, retry=DEFAULT_RETRY_COUNT, scan_timeout=5) -> dict:
+    def discover(self, retry=DEFAULT_RETRY_COUNT, scan_timeout=5) -> dict | None:
         """Find switchbot devices and their advertisement data."""
 
         devices = None

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -71,30 +71,26 @@ class SwitchbotDevices:
             if dev.getValueText(7) == UUID:
                 dev_id = dev.addr.replace(":", "")
                 self._services_data[dev_id] = {}
-                self._services_data[dev_id]['mac_address'] = dev.addr
-                self._services_data[dev_id]['rssi'] = dev.rssi
+                self._services_data[dev_id]["mac_address"] = dev.addr
+                self._services_data[dev_id]["rssi"] = dev.rssi
                 for (adtype, desc, value) in dev.getScanData():
                     if adtype == 22:
                         _model = binascii.unhexlify(value[4:6]).decode()
                         if _model == "H":
                             self._services_data[dev_id][
-                                'serviceData'
+                                "serviceData"
                             ] = self._process_wohand(value[4:])
-                            self._services_data[dev_id]['serviceData'][
-                                'model'
-                            ] = _model
-                            self._services_data[dev_id]['serviceData'][
-                                'modelName'
+                            self._services_data[dev_id]["serviceData"]["model"] = _model
+                            self._services_data[dev_id]["serviceData"][
+                                "modelName"
                             ] = "WoHand"
                         if _model == "c":
                             self._services_data[dev_id][
-                                'serviceData'
+                                "serviceData"
                             ] = self._process_wocurtain(value[4:])
-                            self._services_data[dev_id]['serviceData'][
-                                'model'
-                            ] = _model
-                            self._services_data[dev_id]['serviceData'][
-                                'modelName'
+                            self._services_data[dev_id]["serviceData"]["model"] = _model
+                            self._services_data[dev_id]["serviceData"][
+                                "modelName"
                             ] = "WoCurtain"
                     else:
                         self._services_data[dev_id][desc] = value
@@ -106,15 +102,12 @@ class SwitchbotDevices:
         bot_sensors = {}
 
         _sensor_data = binascii.unhexlify(data.encode())
-        bot_sensors["modeSwitch"] = bool(
+        bot_sensors["switchMode"] = bool(
             _sensor_data[1] & 0b10000000
         )  # 128 switch or 0 press
 
         # 64 on or 0 for off
-        if bot_sensors["modeSwitch"]:
-            bot_sensors["state"] = False
-        else:
-            bot_sensors["state"] = bool(_sensor_data[1] & 0b01000000)
+        bot_sensors["state"] = bool(_sensor_data[1] & 0b01000000)
 
         bot_sensors["battery"] = _sensor_data[2] & 0b01111111
 
@@ -141,8 +134,8 @@ class SwitchbotDevices:
         _curtain_devices = {}
 
         for item in self._services_data:
-            if item['serviceData']['model'] == 'c':
-                _curtain_devices[item] = item
+            if self._services_data[item]["serviceData"]["model"] == "c":
+                _curtain_devices[item] = self._services_data[item]
 
         return _curtain_devices
 
@@ -151,10 +144,11 @@ class SwitchbotDevices:
         _bot_devices = {}
 
         for item in self._services_data:
-            if item['serviceData']['model'] == 'H':
-                _bot_devices[item] = item
+            if self._services_data[item]["serviceData"]["model"] == "H":
+                _bot_devices[item] = self._services_data[item]
 
         return _bot_devices
+
 
 class SwitchbotDevice:
     # pylint: disable=too-many-instance-attributes


### PR DESCRIPTION
-Added discovery method. 
-All updates are now handled by single advertisement scan.

This should allow discovery and coordinator based updates in hass integration.

model number (first byte of 16b service data): 
"c" = Curtain
"H" = WoHand or otherwise known as bot. 
"T" = woSensorTH or otherwise known as temp/humidity sensor. (I don't have one and can't test the output)

Returns python dict with all device data of type with single scan.
Example of single curtain (json formated - easier to format in notepad ++):

	"fd8082999999": {
		"mac_address": "fd:80:82:99:99:99",
		"Flags": "06",
		"Manufacturer": "5900fd8082c51181",
		"Complete 128b Services": "cba20d00-224d-11e6-9fb8-0002a5d5c51b",
		"data": {
			"calibration": true,
			"battery": 57,
			"position": 98,
			"lightLevel": 2,
			"rssi": -68
		},
		"model": "c",
		"modelName": "WoCurtain"
	},

Returns python dict with all device data of type with single scan.
Example of returned data for switchbot bot(json formatted - easier to format in notepad ++):

	"e78943999999": {
		"mac_address": "e7:89:43:99:99:99",
		"Flags": "06",
		"Manufacturer": "5900e78943d9fe7c",
		"Complete 128b Services": "cba20d00-224d-11e6-9fb8-0002a5d5c51b",
		"data": {
			"switchMode": true,
			"isOn": true,
			"battery": 91,
			"rssi": -71
		},
		"model": "H",
		"modelName": "WoHand"
	},
