### PR TITLE
Fixed _process_wosensorth() in __init__.py

### DIFF
--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -77,11 +77,12 @@ def _process_wosensorth(data) -> dict:
 
     _sensor_data = binascii.unhexlify(data.encode())
 
-    _temp_sign = _sensor_data[4] & 0b10000000
+    _temp_sign = 1 if _sensor_data[4] & 0b10000000 else -1
     _temp_c = _temp_sign * ((_sensor_data[4] & 0b01111111) + (_sensor_data[3] / 10))
     _temp_f = (_temp_c * 9 / 5) + 32
     _temp_f = (_temp_f * 10) / 10
 
+    _wosensorth_data["temp"] = {}
     _wosensorth_data["temp"]["c"] = _temp_c
     _wosensorth_data["temp"]["f"] = _temp_f
 


### PR DESCRIPTION
Hi @Danielhiversen,

This pull request fixes bugs of a process of Switchbot Meter.
The output of temperature is wrong, and `_wosensorth_data` does not have the `'temp'` key.
See the part of codes of `_process_wosensorth(data)` below, and I added the initialization code and modified the process of the sign flag.

Best Regards.

```
_temp_sign = 1 if _sensor_data[4] & 0b10000000 else -1 # Modified
_temp_c = _temp_sign * ((_sensor_data[4] & 0b01111111) + (_sensor_data[3] / 10))
_temp_f = (_temp_c * 9 / 5) + 32
_temp_f = (_temp_f * 10) / 10

_wosensorth_data["temp"] = {} # Added
_wosensorth_data["temp"]["c"] = _temp_c
_wosensorth_data["temp"]["f"] = _temp_f
```



