### PR TITLE
Additional functionality for Bot and Curtain, reliability improvements.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name = 'PySwitchbot',
     packages = ['switchbot'],
     install_requires=['bluepy'],
-    version = '0.12.0',
+    version = '0.13.0',
     description = 'A library to communicate with Switchbot',
     author='Daniel Hjelseth Hoyer',
     url='https://github.com/Danielhiversen/pySwitchbot/',

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -605,7 +605,7 @@ class SwitchbotCurtain(SwitchbotDevice):
 
         return self._settings
 
-    def get_extended_info_summary(self) -> dict[str, Any]:
+    def get_extended_info_summary(self) -> dict[str, Any] | None:
         """Get basic info for all devices in chain."""
         data = self._get_device_notifications(
             key=CURTAIN_EXT_SUM_KEY, retry=self._retry_count
@@ -624,7 +624,7 @@ class SwitchbotCurtain(SwitchbotDevice):
             "left_to_right" if data[1] & 0b00010000 == 1 else "right_to_left"
         )
 
-        if data[2] != "0b0":
+        if data[2] != 0:
             self.ext_info_sum["device1"] = {}
             self.ext_info_sum["device1"]["openDirectionDefault"] = not bool(
                 data[1] & 0b10000000
@@ -637,7 +637,7 @@ class SwitchbotCurtain(SwitchbotDevice):
 
         return self.ext_info_sum
 
-    def get_extended_info_adv(self) -> dict[str, Any]:
+    def get_extended_info_adv(self) -> dict[str, Any] | None:
         """Get advance page info for device chain."""
         # stateOfCharge:
         # 0:Not charging,

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -324,7 +324,7 @@ class SwitchbotDevice:
             for char in receive_handle:
                 read_result: bytes = char.read()
             return read_result
-        return b""
+        return b"\x00"
 
     def _sendcommand(self, key: str, retry: int) -> bytes:
         send_success = False

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -331,6 +331,13 @@ class SwitchbotDevice:
         command = self._commandkey(key)
         notify_msg = b"\x00"
         _LOGGER.debug("Sending command to switchbot %s", command)
+        if self._device._helper:  # pylint: disable=protected-access
+            if self._device.getState() in ("conn", "scan"):
+                _LOGGER.warning(self._device.getState())
+                _LOGGER.error(
+                    "Device is busy, waiting for %s seconds", self._scan_timeout
+                )
+                time.sleep(self._scan_timeout)
         with CONNECT_LOCK:
             try:
                 self._connect()

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -308,12 +308,13 @@ class SwitchbotDevice:
             _LOGGER.info("Successfully sent command to Switchbot (MAC: %s)", self._mac)
         return write_result
 
-    def _subscribe(self, key: str) -> None:
+    def _subscribe(self) -> None:
         _LOGGER.debug("Subscribe to notifications")
+        enable_notify_flag = b"\x01\x00"  # standard gatt flag to enable notification
         handle = self._device.getCharacteristics(uuid=NOTIFICATION_HANDLE)[0]
         notify_handle = handle.getHandle() + 1
         self._device.writeCharacteristic(
-            notify_handle, bytes.fromhex(key), withResponse=False
+            notify_handle, enable_notify_flag, withResponse=False
         )
 
     def _readkey(self) -> bytes | None:
@@ -440,7 +441,7 @@ class SwitchbotDevice:
         command = self._commandkey(key)
         try:
             self._connect()
-            self._subscribe(command)
+            self._subscribe()
             send_success = self._writekey(command)
             value = self._readkey()
         except bluepy.btle.BTLEException:

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -14,9 +14,9 @@ DEFAULT_RETRY_TIMEOUT = 1
 DEFAULT_SCAN_TIMEOUT = 5
 
 # Switchbot device BTLE handles
-UUID = bluepy.btle.UUID("cba20d00-224d-11e6-9fb8-0002a5d5c51b")
-HANDLE = bluepy.btle.UUID("cba20002-224d-11e6-9fb8-0002a5d5c51b")
-NOTIFICATION_HANDLE = bluepy.btle.UUID("cba20003-224d-11e6-9fb8-0002a5d5c51b")
+UUID = "cba20d00-224d-11e6-9fb8-0002a5d5c51b"
+HANDLE = "cba20002-224d-11e6-9fb8-0002a5d5c51b"
+NOTIFICATION_HANDLE = "cba20003-224d-11e6-9fb8-0002a5d5c51b"
 
 # Keys common to all device types
 DEVICE_GET_BASIC_SETTINGS_KEY = "5702"

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -351,14 +351,11 @@ class SwitchbotDevice:
         notify_msg = b"\x00"
         _LOGGER.debug("Sending command to switchbot %s", command)
         if self._device._helper:  # pylint: disable=protected-access
-            _LOGGER.warning(self._device.getState())
-            if self._device.getState() in ("conn", "scan"):
-                _LOGGER.error(
-                    "Device is in %s state, waiting for %s seconds",
-                    self._device.getState(),
-                    self._scan_timeout,
-                )
-                time.sleep(self._scan_timeout)
+            _LOGGER.warning(
+                "Device is in %s state, calling disconnect first",
+                self._device.getState(),
+            )
+            self._disconnect()
         with CONNECT_LOCK:
             try:
                 self._connect()

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -142,7 +142,9 @@ class GetSwitchbotDevices:
                 retry,
             )
             time.sleep(DEFAULT_RETRY_TIMEOUT)
-            return self.discover(retry - 1, scan_timeout)
+            return self.discover(
+                retry=retry - 1, scan_timeout=scan_timeout, passive=passive
+            )
 
         for dev in devices:
             if dev.getValueText(7) == UUID:
@@ -414,7 +416,9 @@ class SwitchbotDevice:
                 retry,
             )
             time.sleep(DEFAULT_RETRY_TIMEOUT)
-            return self.get_device_data(retry=retry - 1, interface=_interface)
+            return self.get_device_data(
+                retry=retry - 1, interface=_interface, passive=passive
+            )
 
         for dev in devices:
             if self._mac.lower() == dev.addr.lower():

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -14,9 +14,9 @@ DEFAULT_RETRY_TIMEOUT = 1
 DEFAULT_SCAN_TIMEOUT = 5
 
 # Switchbot device BTLE handles
-UUID = "cba20d00-224d-11e6-9fb8-0002a5d5c51b"
-HANDLE = "cba20002-224d-11e6-9fb8-0002a5d5c51b"
-NOTIFICATION_HANDLE = "cba20003-224d-11e6-9fb8-0002a5d5c51b"
+UUID = bluepy.btle.UUID("cba20d00-224d-11e6-9fb8-0002a5d5c51b")
+HANDLE = bluepy.btle.UUID("cba20002-224d-11e6-9fb8-0002a5d5c51b")
+NOTIFICATION_HANDLE = bluepy.btle.UUID("cba20003-224d-11e6-9fb8-0002a5d5c51b")
 
 # Keys common to all device types
 DEVICE_GET_BASIC_SETTINGS_KEY = "5702"

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -333,10 +333,12 @@ class SwitchbotDevice:
         notify_msg = b"\x00"
         _LOGGER.debug("Sending command to switchbot %s", command)
         if self._device._helper:  # pylint: disable=protected-access
+            _LOGGER.warning(self._device.getState())
             if self._device.getState() in ("conn", "scan"):
-                _LOGGER.warning(self._device.getState())
                 _LOGGER.error(
-                    "Device is busy, waiting for %s seconds", self._scan_timeout
+                    "Device is in %s state, waiting for %s seconds",
+                    self._device.getState(),
+                    self._scan_timeout,
                 )
                 time.sleep(self._scan_timeout)
         with CONNECT_LOCK:

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -214,11 +214,11 @@ class GetSwitchbotDevices:
         if not self._adv_data:
             self.discover()
 
-        _curtain_devices = {}
-
-        for device, data in self._adv_data.items():
-            if data.get("model") == "c":
-                _curtain_devices[device] = data
+        _curtain_devices = {
+            device: data
+            for device, data in self._adv_data.items()
+            if data.get("model") == "c"
+        }
 
         return _curtain_devices
 
@@ -227,11 +227,11 @@ class GetSwitchbotDevices:
         if not self._adv_data:
             self.discover()
 
-        _bot_devices = {}
-
-        for device, data in self._adv_data.items():
-            if data.get("model") == "H":
-                _bot_devices[device] = data
+        _bot_devices = {
+            device: data
+            for device, data in self._adv_data.items()
+            if data.get("model") == "H"
+        }
 
         return _bot_devices
 
@@ -240,11 +240,11 @@ class GetSwitchbotDevices:
         if not self._adv_data:
             self.discover()
 
-        _bot_temp = {}
-
-        for device, data in self._adv_data.items():
-            if data.get("model") == "T":
-                _bot_temp[device] = data
+        _bot_temp = {
+            device: data
+            for device, data in self._adv_data.items()
+            if data.get("model") == "T"
+        }
 
         return _bot_temp
 
@@ -253,11 +253,11 @@ class GetSwitchbotDevices:
         if not self._adv_data:
             self.discover()
 
-        _switchbot_data = {}
-
-        for device in self._adv_data.values():
-            if device["mac_address"] == mac:
-                _switchbot_data = device
+        _switchbot_data = {
+            device: data
+            for device, data in self._adv_data.items()
+            if data.get("mac_address") == mac
+        }
 
         return _switchbot_data
 

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -125,6 +125,7 @@ class GetSwitchbotDevices:
                 devices = bluepy.btle.Scanner(self._interface).scan(
                     scan_timeout, passive
                 )
+                time.sleep(0.5)
 
             except bluepy.btle.BTLEManagementError:
                 _LOGGER.error("Error scanning for switchbot devices", exc_info=True)
@@ -348,6 +349,7 @@ class SwitchbotDevice:
                 _LOGGER.warning("Error talking to Switchbot", exc_info=True)
             finally:
                 self._disconnect()
+                time.sleep(0.5)
         if send_success:
             if notify_msg == b"\x07":
                 _LOGGER.error("Password required")
@@ -393,6 +395,7 @@ class SwitchbotDevice:
                 devices = bluepy.btle.Scanner(_interface).scan(
                     self._scan_timeout, passive=passive
                 )
+                time.sleep(0.5)
 
             except bluepy.btle.BTLEManagementError:
                 _LOGGER.error("Error scanning for switchbot devices", exc_info=True)

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -581,7 +581,7 @@ class SwitchbotCurtain(SwitchbotDevice):
             return None
         return self._switchbot_device_data["data"]["position"]
 
-    def get_basic_info(self) -> dict[str, Any]:
+    def get_basic_info(self) -> dict[str, Any] | None:
         """Get device basic settings."""
         settings_data = self._get_device_notifications(
             key=DEVICE_BASIC_SETTINGS_KEY, retry=self._retry_count

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -268,6 +268,7 @@ class SwitchbotDevice(bluepy.btle.Peripheral):
 
         if retry < 1:
             _LOGGER.warning("Switchbot connection failed, stop retry")
+            self._stopHelper()
             raise bluepy.btle.BTLEDisconnectError("Connection Retry exceeded")
 
         if self._helper is None:

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -679,7 +679,19 @@ class SwitchbotCurtain(SwitchbotDevice):
             self.ext_info_adv["device1"] = {}
             self.ext_info_adv["device1"]["battery"] = data[4]
             self.ext_info_adv["device1"]["firmware"] = data[5] / 10.0
-            self.ext_info_adv["device1"]["stateOfCharge"] = data[6]
+
+            if data[6] == 0:
+                self.ext_info_adv["device0"]["stateOfCharge"] = "not_charging"
+            elif data[6] == 1:
+                self.ext_info_adv["device0"]["stateOfCharge"] = "charging_by_adapter"
+            elif data[6] == 2:
+                self.ext_info_adv["device0"]["stateOfCharge"] = "charging_by_solar"
+            elif data[6] == 3 or 4:
+                self.ext_info_adv["device0"]["stateOfCharge"] = "fully_charged"
+            elif data[6] == 5:
+                self.ext_info_adv["device0"]["stateOfCharge"] = "solar_not_charging"
+            elif data[6] == 6:
+                self.ext_info_adv["device0"]["stateOfCharge"] = "charging_error"
 
         return self.ext_info_adv
 

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -263,7 +263,7 @@ class SwitchbotDevice(bluepy.btle.Peripheral):
             )
 
     # pylint: disable=arguments-differ
-    def _connect(self, retry: int, timeout: int = None) -> None:
+    def _connect(self, retry: int, timeout: int | None = None) -> None:
         _LOGGER.debug("Connecting to Switchbot")
 
         if retry < 1:  # failsafe
@@ -368,7 +368,7 @@ class SwitchbotDevice(bluepy.btle.Peripheral):
 
     def _readkey(self) -> bytes:
         if self._helper is None:
-            return
+            return b''
         _LOGGER.debug("Prepare to read")
         try:
             receive_handle = self.getCharacteristics(uuid=_sb_uuid("rx"))
@@ -383,7 +383,7 @@ class SwitchbotDevice(bluepy.btle.Peripheral):
             )
             raise
 
-    def _sendcommand(self, key: str, retry: int, timeout: int = None) -> bytes:
+    def _sendcommand(self, key: str, retry: int, timeout: int | None = None) -> bytes:
         send_success = False
         command = self._commandkey(key)
         notify_msg = b"\x00"

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -116,8 +116,6 @@ def _btle_scan(
     with CONNECT_LOCK:
         try:
             devices = bluepy.btle.Scanner(interface).scan(scan_timeout, passive)
-            time.sleep(0.5)
-
         except bluepy.btle.BTLEManagementError:
             _LOGGER.error("Error scanning for switchbot devices", exc_info=True)
 
@@ -350,12 +348,6 @@ class SwitchbotDevice:
         command = self._commandkey(key)
         notify_msg = b"\x00"
         _LOGGER.debug("Sending command to switchbot %s", command)
-        if self._device._helper:  # pylint: disable=protected-access
-            _LOGGER.warning(
-                "Device is in %s state, calling disconnect first",
-                self._device.getState(),
-            )
-            self._disconnect()
         with CONNECT_LOCK:
             try:
                 self._connect()
@@ -366,7 +358,6 @@ class SwitchbotDevice:
                 _LOGGER.warning("Error talking to Switchbot", exc_info=True)
             finally:
                 self._disconnect()
-                time.sleep(1)
         if send_success:
             if notify_msg == b"\x07":
                 _LOGGER.error("Password required")

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -269,6 +269,7 @@ class SwitchbotDevice(bluepy.btle.Peripheral):
         self._writeCmd("conn %s %s\n" % (self._mac, bluepy.btle.ADDR_TYPE_RANDOM))
         rsp = self._getResp("stat", timeout)
         if rsp is None:
+            self._stopHelper()
             raise bluepy.btle.BTLEDisconnectError(
                 "Timed out while trying to connect to peripheral %s" % self._mac,
                 rsp,

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -1,6 +1,6 @@
 """Library to handle connection with Switchbot."""
 from __future__ import annotations
-
+#add extended options
 import binascii
 import logging
 import threading

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -349,7 +349,7 @@ class SwitchbotDevice:
                 _LOGGER.warning("Error talking to Switchbot", exc_info=True)
             finally:
                 self._disconnect()
-                time.sleep(0.5)
+                time.sleep(1)
         if send_success:
             if notify_msg == b"\x07":
                 _LOGGER.error("Password required")

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -514,7 +514,7 @@ class Switchbot(SwitchbotDevice):
 
         return False
 
-    def set_long_press(self, duration: int = 3) -> bool:
+    def set_long_press(self, duration: int = 0) -> bool:
         """Set bot long press duration."""
         duration_key = f"{duration:0{2}x}"  # to hex with padding to double digit
 

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -267,7 +267,6 @@ class SwitchbotDevice(bluepy.btle.Peripheral):
         _LOGGER.debug("Connecting to Switchbot")
 
         if retry < 1:  # failsafe
-            _LOGGER.warning("Switchbot connection attempt failed")
             self._stopHelper()
             return
 

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -102,7 +102,7 @@ def _process_wosensorth(data: bytes) -> dict[str, Any]:
 class GetSwitchbotDevices:
     """Scan for all Switchbot devices and return by type."""
 
-    def __init__(self, interface: int | None = None) -> None:
+    def __init__(self, interface: int = 0) -> None:
         """Get switchbot devices class constructor."""
         self._interface = interface
         self._all_services_data: dict[str, Any] = {}
@@ -244,7 +244,7 @@ class SwitchbotDevice:
         self,
         mac: str,
         password: str | None = None,
-        interface: int | None = None,
+        interface: int = 0,
         **kwargs: Any,
     ) -> None:
         """Switchbot base class constructor."""
@@ -459,11 +459,13 @@ class Switchbot(SwitchbotDevice):
     def turn_on(self) -> bool:
         """Turn device on."""
         result = self._sendcommand(ON_KEY, self._retry_count)
+
         if result[0] == 1:
             return True
 
         if result[0] == 5:
-            _LOGGER.error("Action not supported in current mode")
+            _LOGGER.warning("Bot is in press mode and doesn't have on state")
+            return True
 
         return False
 
@@ -474,7 +476,8 @@ class Switchbot(SwitchbotDevice):
             return True
 
         if result[0] == 5:
-            _LOGGER.error("Action not supported in current mode")
+            _LOGGER.warning("Bot is in press mode and doesn't have off state")
+            return True
 
         return False
 
@@ -485,7 +488,8 @@ class Switchbot(SwitchbotDevice):
             return True
 
         if result[0] == 5:
-            _LOGGER.error("Action not supported in current mode")
+            _LOGGER.warning("Bot is in switch mode")
+            return True
 
         return False
 

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -266,7 +266,7 @@ class SwitchbotDevice(bluepy.btle.Peripheral):
     def _connect(self, retry: int, timeout: int = None) -> None:
         _LOGGER.debug("Connecting to Switchbot")
 
-        if retry < 1:
+        if retry < 1:  # failsafe
             _LOGGER.warning("Switchbot connection attempt failed")
             self._stopHelper()
             return
@@ -294,9 +294,6 @@ class SwitchbotDevice(bluepy.btle.Peripheral):
             )
 
             if errcode == "connfail":  # not terminal, can retry connection.
-                _LOGGER.warning(
-                    "Connection failed, retrying connection to %s", self._mac
-                )
                 return self._connect(retry - 1, timeout)
 
             if errcode == "nomgmt":

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -27,6 +27,8 @@ DEVICE_SET_EXTENDED_KEY = "570f"
 PRESS_KEY = "570100"
 ON_KEY = "570101"
 OFF_KEY = "570102"
+DOWN_KEY = "570103"
+UP_KEY = "570104"
 
 # Curtain keys
 OPEN_KEY = "570f450105ff00"  # 570F4501010100
@@ -469,7 +471,7 @@ class Switchbot(SwitchbotDevice):
             return True
 
         if result[0] == 5:
-            _LOGGER.warning("Bot is in press mode and doesn't have on state")
+            _LOGGER.debug("Bot is in press mode and doesn't have on state")
             return True
 
         return False
@@ -481,7 +483,31 @@ class Switchbot(SwitchbotDevice):
             return True
 
         if result[0] == 5:
-            _LOGGER.warning("Bot is in press mode and doesn't have off state")
+            _LOGGER.debug("Bot is in press mode and doesn't have off state")
+            return True
+
+        return False
+
+    def hand_up(self) -> bool:
+        """Raise device arm."""
+        result = self._sendcommand(UP_KEY, self._retry_count)
+        if result[0] == 1:
+            return True
+
+        if result[0] == 5:
+            _LOGGER.debug("Bot is in press mode")
+            return True
+
+        return False
+
+    def hand_down(self) -> bool:
+        """Lower device arm."""
+        result = self._sendcommand(DOWN_KEY, self._retry_count)
+        if result[0] == 1:
+            return True
+
+        if result[0] == 5:
+            _LOGGER.debug("Bot is in press mode")
             return True
 
         return False
@@ -493,7 +519,7 @@ class Switchbot(SwitchbotDevice):
             return True
 
         if result[0] == 5:
-            _LOGGER.warning("Bot is in switch mode")
+            _LOGGER.debug("Bot is in switch mode")
             return True
 
         return False

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -645,7 +645,7 @@ class SwitchbotCurtain(SwitchbotDevice):
         # 2:Solar panel charging,
         # 3:The adapter connection is full,
         # 4:The solar panel connection is full,
-        # 5:The solar panel is connected and not charged when it is not fully charged.
+        # 5:The solar panel is connected and not charging when it is not fully charged.
         # 6:Hardware error.
 
         data = self._get_device_notifications(
@@ -663,20 +663,11 @@ class SwitchbotCurtain(SwitchbotDevice):
 
         if data[4]:
             self.ext_info_adv["device1"] = {}
-            self.ext_info_adv["device1"]["battery"] = data[1]
-            self.ext_info_adv["device1"]["firmware"] = data[2] / 10.0
-            self.ext_info_adv["device1"]["stateOfCharge"] = data[3]
+            self.ext_info_adv["device1"]["battery"] = data[4]
+            self.ext_info_adv["device1"]["firmware"] = data[5] / 10.0
+            self.ext_info_adv["device1"]["stateOfCharge"] = data[6]
 
         return self.ext_info_adv
-
-    def get_extended_info_chain(self) -> dict[str, Any]:
-        """Get device chain info."""
-        ext_chain_info = self._get_device_notifications(
-            key=CURTAIN_EXT_CHAIN_INFO_KEY,
-            retry=self._retry_count,
-        )
-
-        return ext_chain_info
 
     def get_light_level(self) -> Any:
         """Return cached light level."""


### PR DESCRIPTION
Bug Fixes:
- The _connect function now waits while another bluepy operation is in progress!

Common:
- Changed ```get_basic_info``` function to allow reuse for any device notifications via key.
- Combine ```_get_basic_info``` and ```send_command``` methods.
  - Check actual SB response to command issued. (Success/Fail, some also return the SB state. Will expand on this in future pull requests.)
  - Inform if password required or password incorrect.
- Allow passive scanning if the users' environment requires. (Could be used for background monitoring of state changes)
- Optimization of BTLE Scanning functions.
- Discover returns ADV data for unsupported switchbots. (To facilitate adding support for other SB devices) 

Bot:
- Add functions to set Bot mode. 
  - Set Bot to switch/toggle or inverse switch mode.
  - Set strength of bot arm.
  - Set bot long press duration in seconds.
- Add Execute Arm up/down function to Bot.

Curtain:
- Add get extended settings for curtains.
- btle scan adv data also returns additional data:
  - Inmotion (when busy moving) and deviceChain (if grouped curtain bots). The example is for the 1s one in the chain)
 
```
  	"777777777777": {
		"mac_address": "77:77:77:77:77:77",
		"isEncrypted": false,
		"model": "c",
		"data": {
			"calibration": true,
			"battery": 40,
			"inMotion": false,
			"position": 100,
			"lightLevel": 2,
			"deviceChain": 1,
			"rssi": -71
		},
		"modelName": "WoCurtain"
```

# Added device info methods:

```curtain = switchbot.SwitchbotCurtain(mac="d6:2f:ff:ff:ff:ff")```

```curtain.get_extended_info_summary()```

Successfully retrieved data from device d6:2f:ff:ff:ff:ff
{'device0': {'openDirectionDefault': False, 'touchToOpen': True, 'light': True, 'openDirection': 'right_to_left'}, 'device1': {'openDirectionDefault': False, 'touchToOpen': True, 'light': True, 'openDirection': 'left_to_right'}}

```curtain.get_extended_info_adv()```

Successfully retrieved data from device d6:2f:ff:ff:ff:ff
{'device0': {'battery': 82, 'firmware': 3.1, 'stateOfCharge': 'not_charging'}, 'device1': {'battery': 83, 'firmware': 3.1, 'stateOfCharge': 'not_charging'}}
