### PR TITLE
Fix erroneously returning "success" when the command failed.

### DIFF
--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -368,7 +368,7 @@ class SwitchbotDevice(bluepy.btle.Peripheral):
 
     def _readkey(self) -> bytes:
         if self._helper is None:
-            return b""
+            return
         _LOGGER.debug("Prepare to read")
         try:
             receive_handle = self.getCharacteristics(uuid=_sb_uuid("rx"))
@@ -399,9 +399,10 @@ class SwitchbotDevice(bluepy.btle.Peripheral):
                 _LOGGER.warning("Error connecting to Switchbot", exc_info=True)
             else:
                 try:
-                    self._subscribe()
-                    send_success = self._writekey(command)
-                    notify_msg = self._readkey()
+                    while self._helper:
+                        self._subscribe()
+                        send_success = self._writekey(command)
+                        notify_msg = self._readkey()
                 except bluepy.btle.BTLEException:
                     _LOGGER.warning(
                         "Error sending commands to Switchbot", exc_info=True

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -398,19 +398,19 @@ class SwitchbotDevice(bluepy.btle.Peripheral):
             except bluepy.btle.BTLEException:
                 _LOGGER.warning("Error connecting to Switchbot", exc_info=True)
             else:
+                self._subscribe()
                 try:
-                    with self._helper:
-                        self._subscribe()
-                        send_success = self._writekey(command)
-                        notify_msg = self._readkey()
+                    send_success = self._writekey(command)
+                    print("send_success:", send_success)
                 except bluepy.btle.BTLEException:
                     _LOGGER.warning(
                         "Error sending commands to Switchbot", exc_info=True
                     )
+                notify_msg = self._readkey()
             finally:
                 self.disconnect()
 
-        print(notify_msg)
+        print("notify message", notify_msg)
 
         if send_success:
             if notify_msg == b"\x07":

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -320,6 +320,11 @@ class SwitchbotDevice(bluepy.btle.Peripheral):
                 "Failed to connect to peripheral %s, rsp: %s" % (self._mac, rsp)
             )
 
+        if self._helper is None:
+            raise bluepy.btle.BTLEException(
+                "Error from bluepy-helper (%s)" % "Helper not started", rsp
+            )
+
     def _commandkey(self, key: str) -> str:
         if self._password_encoded is None:
             return key

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -399,7 +399,7 @@ class SwitchbotDevice(bluepy.btle.Peripheral):
                 _LOGGER.warning("Error connecting to Switchbot", exc_info=True)
             else:
                 try:
-                    while self._helper:
+                    if self._helper:
                         self._subscribe()
                         send_success = self._writekey(command)
                         notify_msg = self._readkey()

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -377,9 +377,7 @@ class SwitchbotDevice(bluepy.btle.Peripheral):
             )
             raise
 
-    def _sendcommand(
-        self, key: str, retry: int, timeout: int | None = None
-    ) -> None | bytes:
+    def _sendcommand(self, key: str, retry: int, timeout: int | None = None) -> bytes:
         command = self._commandkey(key)
         notify_msg = None
         _LOGGER.debug("Sending command to switchbot %s", command)
@@ -418,7 +416,7 @@ class SwitchbotDevice(bluepy.btle.Peripheral):
             _LOGGER.error(
                 "Switchbot communication failed. Stopping trying", exc_info=True
             )
-            return notify_msg
+            return b"\x00"
         _LOGGER.warning("Cannot connect to Switchbot. Retrying (remaining: %d)", retry)
         time.sleep(DEFAULT_RETRY_TIMEOUT)
         return self._sendcommand(key, retry - 1)

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -363,7 +363,7 @@ class SwitchbotDevice(bluepy.btle.Peripheral):
         return True
 
     def _readkey(self) -> bytes:
-        _LOGGER.debug("Prepare to read")
+        _LOGGER.debug("Prepare to read notification from switchbot")
         if self._helper is None:
             return b"\x00"
         try:
@@ -378,7 +378,7 @@ class SwitchbotDevice(bluepy.btle.Peripheral):
             return read_result
 
         # Could disconnect before reading response. Assume it worked as this is executed after issueing command.
-        if self.getState() == "disc":
+        if self._helper and self.getState() == "disc":
             return b"\x01"
 
         return b"\x00"

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -366,16 +366,15 @@ class SwitchbotDevice(bluepy.btle.Peripheral):
         _LOGGER.debug("Prepare to read")
         try:
             receive_handle = self.getCharacteristics(uuid=_sb_uuid("rx"))
-            if receive_handle:
-                for char in receive_handle:
-                    read_result: bytes = char.read()
-                return read_result
-            return b"\x00"
         except bluepy.btle.BTLEException:
             _LOGGER.warning(
                 "Error while reading notifications from Switchbot", exc_info=True
             )
-            raise
+        else:
+            # if receive_handle:
+            for char in receive_handle:
+                read_result: bytes = char.read()
+            return read_result
 
     def _sendcommand(self, key: str, retry: int, timeout: int | None = None) -> bytes:
         command = self._commandkey(key)

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -371,10 +371,11 @@ class SwitchbotDevice(bluepy.btle.Peripheral):
                 "Error while reading notifications from Switchbot", exc_info=True
             )
         else:
-            # if receive_handle:
             for char in receive_handle:
                 read_result: bytes = char.read()
             return read_result
+        # Could disconnect before reading response. Assume it worked as this is executed after issueing command.
+        return b"\x01"
 
     def _sendcommand(self, key: str, retry: int, timeout: int | None = None) -> bytes:
         command = self._commandkey(key)

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -263,7 +263,7 @@ class SwitchbotDevice(bluepy.btle.Peripheral):
             )
 
     # pylint: disable=arguments-differ
-    def _connect(self, retry: int, timeout: int | None = None) -> None:
+    def _connect(self, retry: int, timeout: int | None = 1) -> None:
         _LOGGER.debug("Connecting to Switchbot")
 
         if retry < 1:  # failsafe
@@ -361,8 +361,9 @@ class SwitchbotDevice(bluepy.btle.Peripheral):
             raise
 
     def _readkey(self) -> bytes:
+        # Could disconnect before reading response. Assume it worked as this is executed after issueing command.
         if self._helper is None:
-            return
+            return b"\x01"
         _LOGGER.debug("Prepare to read")
         try:
             receive_handle = self.getCharacteristics(uuid=_sb_uuid("rx"))
@@ -374,7 +375,7 @@ class SwitchbotDevice(bluepy.btle.Peripheral):
             for char in receive_handle:
                 read_result: bytes = char.read()
             return read_result
-        # Could disconnect before reading response. Assume it worked as this is executed after issueing command.
+
         return b"\x01"
 
     def _sendcommand(self, key: str, retry: int, timeout: int | None = None) -> bytes:

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -320,11 +320,6 @@ class SwitchbotDevice(bluepy.btle.Peripheral):
                 "Failed to connect to peripheral %s, rsp: %s" % (self._mac, rsp)
             )
 
-        if self._helper is None:
-            raise bluepy.btle.BTLEException(
-                "Error from bluepy-helper (%s)" % "Helper not started", rsp
-            )
-
     def _commandkey(self, key: str) -> str:
         if self._password_encoded is None:
             return key
@@ -373,7 +368,10 @@ class SwitchbotDevice(bluepy.btle.Peripheral):
             return read_result
 
         # Could disconnect before reading response. Assume it worked as this is executed after issueing command.
-        return b"\x01"
+        if self.getState() == "disc":
+            return b"\x01"
+
+        return b"\x00"
 
     def _sendcommand(self, key: str, retry: int, timeout: int | None = None) -> bytes:
         command = self._commandkey(key)

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -40,7 +40,6 @@ KEY_PASSWORD_PREFIX = "571"
 _LOGGER = logging.getLogger(__name__)
 CONNECT_LOCK = Lock()
 
-#fix connectivity failure notifications
 def _sb_uuid(comms_type: str = "service") -> bluepy.btle.UUID:
     """Return Switchbot UUID."""
 
@@ -402,6 +401,9 @@ class SwitchbotDevice(bluepy.btle.Peripheral):
                 _LOGGER.warning("Error talking to Switchbot", exc_info=True)
             finally:
                 self.disconnect()
+
+        print(notify_msg)
+                
         if send_success:
             if notify_msg == b"\x07":
                 _LOGGER.error("Password required")

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -364,6 +364,8 @@ class SwitchbotDevice(bluepy.btle.Peripheral):
 
     def _readkey(self) -> bytes:
         _LOGGER.debug("Prepare to read")
+        if self._helper is None:
+            return b"\x00"
         try:
             receive_handle = self.getCharacteristics(uuid=_sb_uuid("rx"))
         except bluepy.btle.BTLEException:

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -399,7 +399,7 @@ class SwitchbotDevice(bluepy.btle.Peripheral):
                 _LOGGER.warning("Error connecting to Switchbot", exc_info=True)
             else:
                 try:
-                    if self._helper:
+                    with self._helper:
                         self._subscribe()
                         send_success = self._writekey(command)
                         notify_msg = self._readkey()

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -263,7 +263,7 @@ class SwitchbotDevice(bluepy.btle.Peripheral):
             )
 
     # pylint: disable=arguments-differ
-    def _connect(self, retry: int, timeout: int | None = 1) -> None:
+    def _connect(self, retry: int, timeout: int | None = None) -> None:
         _LOGGER.debug("Connecting to Switchbot")
 
         if retry < 1:  # failsafe

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -40,7 +40,7 @@ KEY_PASSWORD_PREFIX = "571"
 _LOGGER = logging.getLogger(__name__)
 CONNECT_LOCK = Lock()
 
-
+#fix connectivity failure notifications
 def _sb_uuid(comms_type: str = "service") -> bluepy.btle.UUID:
     """Return Switchbot UUID."""
 

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -40,6 +40,7 @@ KEY_PASSWORD_PREFIX = "571"
 _LOGGER = logging.getLogger(__name__)
 CONNECT_LOCK = Lock()
 
+
 def _sb_uuid(comms_type: str = "service") -> bluepy.btle.UUID:
     """Return Switchbot UUID."""
 
@@ -367,7 +368,7 @@ class SwitchbotDevice(bluepy.btle.Peripheral):
 
     def _readkey(self) -> bytes:
         if self._helper is None:
-            return b''
+            return b""
         _LOGGER.debug("Prepare to read")
         try:
             receive_handle = self.getCharacteristics(uuid=_sb_uuid("rx"))
@@ -394,16 +395,22 @@ class SwitchbotDevice(bluepy.btle.Peripheral):
         with CONNECT_LOCK:
             try:
                 self._connect(retry, timeout)
-                self._subscribe()
-                send_success = self._writekey(command)
-                notify_msg = self._readkey()
             except bluepy.btle.BTLEException:
-                _LOGGER.warning("Error talking to Switchbot", exc_info=True)
+                _LOGGER.warning("Error connecting to Switchbot", exc_info=True)
+            else:
+                try:
+                    self._subscribe()
+                    send_success = self._writekey(command)
+                    notify_msg = self._readkey()
+                except bluepy.btle.BTLEException:
+                    _LOGGER.warning(
+                        "Error sending commands to Switchbot", exc_info=True
+                    )
             finally:
                 self.disconnect()
 
         print(notify_msg)
-                
+
         if send_success:
             if notify_msg == b"\x07":
                 _LOGGER.error("Password required")


### PR DESCRIPTION
* Fix switchbot erroneously returning "success" on execution when signal is weak/intermittent. 
* Workaround for erroneously returning "failed" when a disconnect occurs after the command is sent. (Read notification step)