### PR TITLE
Fix issue where switchbot stops responding due to "disc" status

### DIFF
--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -280,7 +280,7 @@ class SwitchbotDevice(bluepy.btle.Peripheral):
         while rsp.get("state") and rsp["state"][0] in [
             "tryconn",
             "scan",
-            "disc",
+            #"disc",    
         ]:  # Wait for any operations to finish.
             rsp = self._getResp(["stat", "err"], timeout)
 

--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -280,7 +280,6 @@ class SwitchbotDevice(bluepy.btle.Peripheral):
         while rsp.get("state") and rsp["state"][0] in [
             "tryconn",
             "scan",
-            #"disc",    
         ]:  # Wait for any operations to finish.
             rsp = self._getResp(["stat", "err"], timeout)
 


### PR DESCRIPTION
Commenting line 283 out to avoid the issue where switchbot stops responding until HA restart. 
If the switchbot is in disc state, it tries to read a response but it will never get one. By removing disc from the while loop, it will fall into BTLEDisconnectError exception and retry properly the next time around, without any deadlocks.