### PR TITLE
Sensor Discard temperature alert status flags

### DIFF
--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -86,7 +86,7 @@ def _process_wosensorth(data: bytes) -> dict[str, object]:
     """Process woSensorTH/Temp sensor services data."""
 
     _temp_sign = 1 if data[4] & 0b10000000 else -1
-    _temp_c = _temp_sign * ((data[4] & 0b01111111) + (data[3] / 10))
+    _temp_c = _temp_sign * ((data[4] & 0b01111111) + ((data[3] & 0b00001111 / 10))
     _temp_f = (_temp_c * 9 / 5) + 32
     _temp_f = (_temp_f * 10) / 10
 


### PR DESCRIPTION
Per [specification the broadcast message](https://github.com/OpenWonderLabs/SwitchBotAPI-BLE/blob/latest/devicetypes/meter.md#meter-broadcast-message-format) byte 3 includes the device temperature and humidity alert status flags and the decimal temperature (in the last 4 bits). Therefore, only the last 4 bits should be considered to extract the temperature in Celsius. 

Without this fix, when the sensor is within the alert range the flags cause the temperature to interpreted incorrectly.