### PR TITLE
Remove filter to handle new UUIDs in SwitchBot firmware

### DIFF
--- a/switchbot/__init__.py
+++ b/switchbot/__init__.py
@@ -114,8 +114,12 @@ class GetSwitchbotDevices:
         advertisement_data: bleak.backends.scanner.AdvertisementData,
     ) -> None:
         """BTLE adv scan callback."""
+        _services = list(advertisement_data.service_data.values())
+        if not _services:
+            return
+        _service_data = _services[0]
+
         _device = device.address.replace(":", "").lower()
-        _service_data = list(advertisement_data.service_data.values())[0]
         _model = chr(_service_data[0] & 0b01111111)
 
         supported_types: dict[str, dict[str, Any]] = {
@@ -153,7 +157,8 @@ class GetSwitchbotDevices:
         devices = None
 
         devices = bleak.BleakScanner(
-            filters={"UUIDs": [str(_sb_uuid())]},
+            # TODO: Find new UUIDs to filter on. For example, see
+            # https://github.com/OpenWonderLabs/SwitchBotAPI-BLE/blob/4ad138bb09f0fbbfa41b152ca327a78c1d0b6ba9/devicetypes/meter.md
             adapter=self._interface,
         )
         devices.register_detection_callback(self.detection_callback)


### PR DESCRIPTION
The new SwitchBot firmware advertises its services differently, making the old UUID filter not find any SwitchBot devices. This change is a quick-fix to remove the filter and simply allow the rest of the discovery code to handle it as before.

I don't really know Bluetooth so this is just a total hack that seemed to work. But from reading of the rest of the code, it's still handling advertisement data and making sure it's a supported model, so this change shouldn't hurt. 

In theory, this should be backwards compatible with the old firmware since the rest of the discovery and initialization is exactly the same, but I don't have many devices to test with. Running a scan, I was able to find my own SwitchBot thermometer, and a neighbour's "WoHand" device, which I'm assuming is a switch. Before, I wasn't able to find any devices.

See also https://github.com/devWaves/SwitchBot-MQTT-BLE-ESP32/issues/80

This seems to address https://github.com/home-assistant/core/issues/70262, since after this patch I was able to have HomeAssistant discover my neighbour's switch.