### PR TITLE
Use bleak-retry-connector to handle transient connection errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name = 'PySwitchbot',
     packages = ['switchbot'],
-    install_requires=['bleak'],
+    install_requires=['bleak', 'bleak-retry-connector'],
     version = '0.15.0',
     description = 'A library to communicate with Switchbot',
     author='Daniel Hjelseth Hoyer',


### PR DESCRIPTION
We built bleak-retry-connector for aiohomekit to handle the transient errors that happen when using bleak with dbus since
we were missing disconnected events. As switchbots seem to fail in the same way with bleak on dbus, using the library
made the problem go away.

Also, the default connect timeout is too low which means [services cannot be resolved in time](https://github.com/hbldh/bleak/blob/0361ba4b7e4682f4e97ecacaab4499b84c70f288/bleak/backends/bluezdbus/client.py#L316) so it disconnects in the middle of the connection leaving things in a bad state which is likely why the retry timeout option was added.  Although it might have been added for not finding the device via discovery and then added to the client path as well.  It makes sense in the scanner path since sometimes the device can fall out of the list, but shouldn't be needed in the client path as long as the connect timeout doesn't cause a disconnect in the middle of services being resolved which the current low timeout will do.

The short version is we don't count transient errors as needing to wait, and since they seem to happen often, it makes the action quite a bit faster if we hit a transient one as we try again right away instead of sleeping.

This should also fix the issue reported here https://github.com/Danielhiversen/pySwitchbot/pull/48#issuecomment-1193113155

```
2022-07-23 21:53:42.549 DEBUG (MainThread) [bleak_retry_connector] FD:60:30:55:92:57: WoHand: Connecting (attempt: 1)
2022-07-23 21:53:44.820 DEBUG (MainThread) [bleak_retry_connector] FD:60:30:55:92:57: WoHand: Failed to connect: [org.bluez.Error.Failed] le-connection-abort-by-local (attempt: 1)
2022-07-23 21:53:44.820 DEBUG (MainThread) [bleak_retry_connector] FD:60:30:55:92:57: WoHand: Connecting (attempt: 2)
2022-07-23 21:53:45.843 DEBUG (MainThread) [bleak_retry_connector] FD:60:30:55:92:57: WoHand: Failed to connect: [org.bluez.Error.Failed] le-connection-abort-by-local (attempt: 2)
2022-07-23 21:53:45.843 DEBUG (MainThread) [bleak_retry_connector] FD:60:30:55:92:57: WoHand: Connecting (attempt: 3)
2022-07-23 21:53:47.544 DEBUG (MainThread) [bleak_retry_connector] FD:60:30:55:92:57: WoHand: Connected (attempt: 3)
```