### PR TITLE
Require bleak-retry-connector>=1.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name = 'PySwitchbot',
     packages = ['switchbot'],
-    install_requires=['bleak', 'bleak-retry-connector'],
+    install_requires=['bleak', 'bleak-retry-connector>=1.1.1'],
     version = '0.17.1',
     description = 'A library to communicate with Switchbot',
     author='Daniel Hjelseth Hoyer',


### PR DESCRIPTION
There is a fix in bleak-retry-connector>=1.1.1 for bleak connect
blocking forever when the dbus connection is overloaded or stalled