### PR TITLE
Bump bleak-retry-connector>=1.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name = 'PySwitchbot',
     packages = ['switchbot'],
-    install_requires=['async_timeout>=4.0.1', 'bleak', 'bleak-retry-connector>=1.1.1'],
+    install_requires=['async_timeout>=4.0.1', 'bleak', 'bleak-retry-connector>=1.2.0'],
     version = '0.17.2',
     description = 'A library to communicate with Switchbot',
     author='Daniel Hjelseth Hoyer',


### PR DESCRIPTION
Now handles broken pipe errors from the underlying
dbus connection