### PR TITLE
Fix for "ValueError: non-hexadecimal number found in fromhex()" raised with some passwords

### DIFF
--- a/switchbot/devices/device.py
+++ b/switchbot/devices/device.py
@@ -58,7 +58,7 @@ class SwitchbotDevice:
         if password is None or password == "":
             self._password_encoded = None
         else:
-            self._password_encoded = "%x" % (
+            self._password_encoded = "%08x" % (
                 binascii.crc32(password.encode("ascii")) & 0xFFFFFFFF
             )
 


### PR DESCRIPTION
I started using the home assistant integration and stumbled upon the following error:
```
  File "/usr/local/lib/python3.10/site-packages/switchbot/__init__.py", line 474, in turn_on
    result = await self._sendcommand(ON_KEY, self._retry_count)
  File "/usr/local/lib/python3.10/site-packages/switchbot/__init__.py", line 354, in _sendcommand
    command = bytearray.fromhex(self._commandkey(key))
ValueError: non-hexadecimal number found in fromhex() arg at position 13
```
I narrowed it down to this format string. 

Formatting with %x may result in a shorter string, e.g. if the crc32 < 0x1000000. This will result in shorter command string. We can pad with zeroes to create a fixed-length string.