### PR TITLE
Re-raise on Dbus error after handling disconnect

### DIFF
--- a/switchbot/devices/device.py
+++ b/switchbot/devices/device.py
@@ -238,6 +238,7 @@ class SwitchbotDevice:
                 ex,
             )
             await self._execute_disconnect()
+            raise
         except BleakError as ex:
             # Disconnect so we can reset state and try again
             _LOGGER.debug(


### PR DESCRIPTION
Fixes
```
2022-08-20 15:26:43.835 ERROR (MainThread) [homeassistant.core] Error executing service: <ServiceCall switch.turn_on (c:01GAZ04BA1RQCMQB70FGTB6X20): entity_id=['switch.plug_mini_9506_2']>
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/core.py", line 1735, in catch_exceptions
    await coro_or_task
  File "/usr/src/homeassistant/homeassistant/core.py", line 1754, in _execute_service
    await cast(Callable[[ServiceCall], Awaitable[None]], handler.job.target)(
  File "/usr/src/homeassistant/homeassistant/helpers/entity_component.py", line 204, in handle_service
    await service.entity_service_call(
  File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 676, in entity_service_call
    future.result()  # pop exception if have
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 931, in async_request_call
    await coro
  File "/usr/src/homeassistant/homeassistant/helpers/service.py", line 713, in _handle_entity_call
    await result
  File "/usr/src/homeassistant/homeassistant/components/switchbot/switch.py", line 55, in async_turn_on
    self._last_run_success = bool(await self._device.turn_on())
  File "/usr/local/lib/python3.10/site-packages/switchbot/devices/plug.py", line 22, in turn_on
    result = await self._sendcommand(PLUG_ON_KEY, self._retry_count)
  File "/usr/local/lib/python3.10/site-packages/switchbot/devices/device.py", line 111, in _sendcommand
    return await self._send_command_locked(key, command)
  File "/usr/local/lib/python3.10/site-packages/switchbot/devices/device.py", line 229, in _send_command_locked
    return await self._execute_command_locked(key, command)
  File "/usr/local/lib/python3.10/site-packages/switchbot/devices/device.py", line 252, in _execute_command_locked
    assert self._read_char is not None
AssertionError
```