### PR TITLE
Reduce the disconnect delay

### DIFF
--- a/switchbot/devices/device.py
+++ b/switchbot/devices/device.py
@@ -47,7 +47,7 @@ BLEAK_EXCEPTIONS = (
 # How long to hold the connection
 # to wait for additional commands for
 # disconnecting the device.
-DISCONNECT_DELAY = 49
+DISCONNECT_DELAY = 20
 
 
 class ColorMode(Enum):


### PR DESCRIPTION
We reset this every time an action happens so there is no need to hold it as long. Also now that bleak supports connecting devices that are already connected on the bus there is far less risk of the race so we do not need such a high time

closes #117