### PR TITLE
Lower disconnect delay to 12.5s

### DIFF
--- a/switchbot/devices/device.py
+++ b/switchbot/devices/device.py
@@ -42,7 +42,7 @@ KEY_PASSWORD_PREFIX = "571"
 # How long to hold the connection
 # to wait for additional commands for
 # disconnecting the device.
-DISCONNECT_DELAY = 20
+DISCONNECT_DELAY = 12.5
 
 
 class ColorMode(Enum):


### PR DESCRIPTION
Since these stop advertising when connected we need to low this a bit more to ensure we don't loose track of the device while connected.