### PR TITLE
fix: lower disconnect delay to 8.5 seconds

### DIFF
--- a/switchbot/devices/device.py
+++ b/switchbot/devices/device.py
@@ -42,7 +42,7 @@ KEY_PASSWORD_PREFIX = "571"
 # How long to hold the connection
 # to wait for additional commands for
 # disconnecting the device.
-DISCONNECT_DELAY = 12.5
+DISCONNECT_DELAY = 8.5
 
 
 class ColorMode(Enum):


### PR DESCRIPTION
In https://github.com/Bluetooth-Devices/bleak-retry-connector/pull/67 we discovered that most of the CSR adapters only have 5 connection slots so we want to reduce the chance we will not be able to make a connection because we are still holding the connection to another switchbot.

We still hold the connection for 8.5 seconds every time they do an action to ensure if they want to turn on a light and change a color the whole action happens in a single connection.