### PR TITLE
Support plug mini JP model

### DIFF
--- a/switchbot/adv_parser.py
+++ b/switchbot/adv_parser.py
@@ -79,6 +79,11 @@ SUPPORTED_TYPES: dict[str, SwitchbotSupportedType] = {
         "modelFriendlyName": "Plug Mini",
         "func": process_woplugmini,
     },
+    "j": {
+        "modelName": SwitchbotModel.PLUG_MINI,
+        "modelFriendlyName": "Plug Mini (JP)",
+        "func": process_woplugmini,
+    },
     "u": {
         "modelName": SwitchbotModel.COLOR_BULB,
         "modelFriendlyName": "Color Bulb",


### PR DESCRIPTION
JP model support for Plug mini has been added.

Plug mini has a [JP model](https://www.switchbot.jp/products/switchbot-plug-mini), which is assigned a different model alphabet, but otherwise behaves the same as the global model.