### PR TITLE
Add plug mini power field

### DIFF
--- a/switchbot/adv_parsers/plug.py
+++ b/switchbot/adv_parsers/plug.py
@@ -10,4 +10,5 @@ def process_woplugmini(data: bytes, mfr_data: bytes | None) -> dict[str, bool | 
         "switchMode": True,
         "isOn": mfr_data[7] == 0x80,
         "wifi_rssi": -mfr_data[9],
+        "power": ( ( ( mfr_data[10] << 8 ) + mfr_data[11] ) & 0x7fff ) / 10  # W
     }


### PR DESCRIPTION
Plug mini's advertisement packet contains information on power consumption.
https://github.com/OpenWonderLabs/SwitchBotAPI-BLE/blob/latest/devicetypes/plugmini.md

I have used that information to add a field for power consumption.