### PR TITLE
Clear the services cache when a characteristic is missing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name="PySwitchbot",
     packages=["switchbot", "switchbot.devices", "switchbot.adv_parsers"],
-    install_requires=["async_timeout>=4.0.1", "bleak>=0.17.0", "bleak-retry-connector>=1.17.1"],
+    install_requires=["async_timeout>=4.0.1", "bleak>=0.17.0", "bleak-retry-connector>=2.9.0"],
     version="0.20.7",
     description="A library to communicate with Switchbot",
     author="Daniel Hjelseth Hoyer",

--- a/switchbot/devices/device.py
+++ b/switchbot/devices/device.py
@@ -307,6 +307,17 @@ class SwitchbotBaseDevice:
         await self._ensure_connected()
         try:
             return await self._execute_command_locked(key, command)
+        except CharacteristicMissingError as ex:
+            _LOGGER.debug(
+                "%s: characteristic missing, clearing cache: %s; RSSI: %s",
+                self.name,
+                ex,
+                self.rssi,
+                exc_info=True,
+            )
+            await self._client.clear_cache()
+            await self._execute_forced_disconnect()
+            raise
         except BleakDBusError as ex:
             # Disconnect so we can reset state and try again
             await asyncio.sleep(0.25)


### PR DESCRIPTION
Fixes
`switchbot.devices.device.CharacteristicMissingError: cba20003-224d-11e6-9fb8-0002a5d5c51b`