### PR TITLE
Add read-only support for lock

### DIFF
--- a/switchbot/adv_parser.py
+++ b/switchbot/adv_parser.py
@@ -19,6 +19,7 @@ from .adv_parsers.light_strip import process_wostrip
 from .adv_parsers.meter import process_wosensorth
 from .adv_parsers.motion import process_wopresence
 from .adv_parsers.plug import process_woplugmini
+from .adv_parsers.lock import process_wolock
 from .const import SwitchbotModel
 from .models import SwitchBotAdvertisement
 
@@ -93,6 +94,11 @@ SUPPORTED_TYPES: dict[str, SwitchbotSupportedType] = {
         "modelName": SwitchbotModel.HUMIDIFIER,
         "modelFriendlyName": "Humidifier",
         "func": process_wohumidifier,
+    },
+    "o": {
+        "modelName": SwitchbotModel.LOCK,
+        "modelFriendlyName": "Lock",
+        "func": process_wolock,
     },
 }
 

--- a/switchbot/adv_parsers/lock.py
+++ b/switchbot/adv_parsers/lock.py
@@ -1,0 +1,28 @@
+"""Lock parser."""
+from __future__ import annotations
+from ..const import LockStatus
+
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def process_wolock(data: bytes, mfr_data: bytes | None) -> dict[str, bool | int]:
+    """Process woLock services data."""
+    if mfr_data is None:
+        return {}
+
+    _LOGGER.debug("mfr_data: %s", mfr_data.hex())
+    _LOGGER.debug("data: %s", data.hex())
+
+    return {
+        "battery": data[2] & 0b01111111,
+        "calibration": bool(mfr_data[7] & 0b10000000),
+        "status": LockStatus(mfr_data[7] & 0b01110000),
+        "update_from_secondary_lock": bool(mfr_data[7] & 0b00001000),
+        "door_open": bool(mfr_data[7] & 0b00000100),
+        "double_lock_mode": bool(mfr_data[8] & 0b10000000),
+        "unclosed_alarm": bool(mfr_data[8] & 0b00100000),
+        "unlocked_alarm": bool(mfr_data[8] & 0b00010000),
+        "auto_lock_paused": bool(mfr_data[8] & 0b00000010),
+    }

--- a/switchbot/const.py
+++ b/switchbot/const.py
@@ -1,6 +1,8 @@
 """Library to handle connection with Switchbot."""
 from __future__ import annotations
 
+from enum import Enum
+
 DEFAULT_RETRY_COUNT = 3
 DEFAULT_RETRY_TIMEOUT = 1
 DEFAULT_SCAN_TIMEOUT = 5
@@ -20,3 +22,14 @@ class SwitchbotModel(StrEnum):
     MOTION_SENSOR = "WoPresence"
     COLOR_BULB = "WoBulb"
     CEILING_LIGHT = "WoCeiling"
+    LOCK = "WoLock"
+
+
+class LockStatus(Enum):
+    LOCKED = 0b0000000
+    UNLOCKED = 0b0010000
+    LOCKING = 0b0100000
+    UNLOCKING = 0b0110000
+    LOCKING_STOP = 0b1000000
+    UNLOCKING_STOP = 0b1010000
+    NOT_FULLY_LOCKED = 0b1100000  # Only EU lock type

--- a/switchbot/devices/lock.py
+++ b/switchbot/devices/lock.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/switchbot/discovery.py
+++ b/switchbot/discovery.py
@@ -101,6 +101,10 @@ class GetSwitchbotDevices:
         """Return all WoContact/Contact sensor devices with services data."""
         return await self._get_devices_by_model("d")
 
+    async def get_locks(self) -> dict[str, SwitchBotAdvertisement]:
+        """Return all WoLock/Locks devices with services data."""
+        return await self._get_devices_by_model("o")
+
     async def get_device_data(
         self, address: str
     ) -> dict[str, SwitchBotAdvertisement] | None:


### PR DESCRIPTION
Based on recently released but not yet merged documentation for the lock (https://github.com/OpenWonderLabs/SwitchBotAPI-BLE/blob/4261be8ec49f8b181c54b786b3479c03ad5f80b8/devicetypes/lock.md)
Tested on a sample of one, so I couldn't verify the data related to double lock mode but maybe someone else can verify that part.
Let's hope SwitchBot releases actions for the lock sooner rather than later, but in the meantime maybe we could at least enjoy the read-only part.

PS. after reading through code I wasn't sure which naming convention should I use do I went with snake_case but I can change that if need be