### PR TITLE
Fix handling empty _sb_adv_data

### DIFF
--- a/switchbot/adv_parser.py
+++ b/switchbot/adv_parser.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from functools import lru_cache
-from typing import TypedDict
+from typing import Any, TypedDict
 
 from bleak.backends.device import BLEDevice
 from bleak.backends.scanner import AdvertisementData
@@ -189,7 +189,7 @@ def _parse_data(
     _mfr_data: bytes | None,
     _mfr_id: int | None = None,
     _switchbot_model: SwitchbotModel | None = None,
-) -> SwitchBotAdvertisement | None:
+) -> dict[str, Any] | None:
     """Parse advertisement data."""
     _model = chr(_service_data[0] & 0b01111111) if _service_data else None
 

--- a/switchbot/devices/device.py
+++ b/switchbot/devices/device.py
@@ -482,7 +482,11 @@ class SwitchbotBaseDevice:
 
     def _set_advertisement_data(self, advertisement: SwitchBotAdvertisement) -> None:
         """Set advertisement data."""
-        if advertisement.data.get("data") or not self._sb_adv_data.data.get("data"):
+        if (
+            advertisement.data.get("data")
+            or not self._sb_adv_data
+            or not self._sb_adv_data.data.get("data")
+        ):
             self._sb_adv_data = advertisement
         self._override_adv_data = None
 


### PR DESCRIPTION
Fixes
```
Dec 17 05:20:02 homeassistant homeassistant[471]: 2022-12-16 19:20:02.410 ERROR (MainThread) [homeassistant.components.bluetooth.manager] Error in bluetooth callback
Dec 17 05:20:02 homeassistant homeassistant[471]: Traceback (most recent call last):
Dec 17 05:20:02 homeassistant homeassistant[471]:   File "/usr/src/homeassistant/homeassistant/components/bluetooth/manager.py", line 492, in scanner_adv_received
Dec 17 05:20:02 homeassistant homeassistant[471]:     callback(service_info, BluetoothChange.ADVERTISEMENT)
Dec 17 05:20:02 homeassistant homeassistant[471]:   File "/usr/src/homeassistant/homeassistant/components/switchbot/coordinator.py", line 96, in _async_handle_bluetooth_event
Dec 17 05:20:02 homeassistant homeassistant[471]:     self.device.update_from_advertisement(adv)
Dec 17 05:20:02 homeassistant homeassistant[471]:   File "/usr/local/lib/python3.10/site-packages/switchbot/devices/device.py", line 506, in update_from_advertisement
Dec 17 05:20:02 homeassistant homeassistant[471]:     self._set_advertisement_data(advertisement)
Dec 17 05:20:02 homeassistant homeassistant[471]:   File "/usr/local/lib/python3.10/site-packages/switchbot/devices/device.py", line 485, in _set_advertisement_data
Dec 17 05:20:02 homeassistant homeassistant[471]:     if advertisement.data.get("data") or not self._sb_adv_data.data.get("data"):
Dec 17 05:20:02 homeassistant homeassistant[471]: AttributeError: NoneType object has no attribute data
```