### PR TITLE
Fix missing id for motion sensors in adv parser

### DIFF
--- a/switchbot/adv_parser.py
+++ b/switchbot/adv_parser.py
@@ -59,6 +59,7 @@ SUPPORTED_TYPES: dict[str, SwitchbotSupportedType] = {
         "modelName": SwitchbotModel.MOTION_SENSOR,
         "modelFriendlyName": "Motion Sensor",
         "func": process_wopresence,
+        "manufacturer_id": 2409,
         "manufacturer_data_length": 10,
     },
     "r": {

--- a/tests/test_adv_parser.py
+++ b/tests/test_adv_parser.py
@@ -1022,7 +1022,6 @@ def test_motion_with_light_detected():
     )
 
 
-
 def test_motion_sensor_motion_passive():
     """Test parsing motion sensor with motion data."""
     ble_device = BLEDevice("aa:bb:cc:dd:ee:ff", "any")
@@ -1032,9 +1031,7 @@ def test_motion_sensor_motion_passive():
         tx_power=-127,
         rssi=-87,
     )
-    result = parse_advertisement_data(
-        ble_device, adv_data
-    )
+    result = parse_advertisement_data(ble_device, adv_data)
     assert result == SwitchBotAdvertisement(
         address="aa:bb:cc:dd:ee:ff",
         data={

--- a/tests/test_adv_parser.py
+++ b/tests/test_adv_parser.py
@@ -1020,3 +1020,40 @@ def test_motion_with_light_detected():
         device=ble_device,
         rssi=-84,
     )
+
+
+
+def test_motion_sensor_motion_passive():
+    """Test parsing motion sensor with motion data."""
+    ble_device = BLEDevice("aa:bb:cc:dd:ee:ff", "any")
+    adv_data = generate_advertisement_data(
+        manufacturer_data={2409: b"\xc0!\x9a\xe8\xbcIi\\\x008"},
+        service_data={},
+        tx_power=-127,
+        rssi=-87,
+    )
+    result = parse_advertisement_data(
+        ble_device, adv_data
+    )
+    assert result == SwitchBotAdvertisement(
+        address="aa:bb:cc:dd:ee:ff",
+        data={
+            "data": {
+                "battery": None,
+                "iot": None,
+                "is_light": False,
+                "led": None,
+                "light_intensity": None,
+                "motion_detected": True,
+                "sense_distance": None,
+                "tested": None,
+            },
+            "isEncrypted": False,
+            "model": "s",
+            "modelFriendlyName": "Motion Sensor",
+            "modelName": SwitchbotModel.MOTION_SENSOR,
+            "rawAdvData": None,
+        },
+        device=ble_device,
+        rssi=-87,
+    )


### PR DESCRIPTION
Allows them to be detected from passive only