### PR TITLE
Fire callbacks after updating lock status

### DIFF
--- a/switchbot/devices/lock.py
+++ b/switchbot/devices/lock.py
@@ -164,6 +164,7 @@ class SwitchbotLock(SwitchbotDevice):
             asyncio.create_task(self._disable_notifications())
 
         self._update_parsed_data(lock_data)
+        self._fire_callbacks()
 
     @staticmethod
     def _parse_lock_data(data: bytes) -> dict[str, Any]:


### PR DESCRIPTION
While implementing the lock for HA I found out that the entity status updates very slowly where it should have been almost instantaneous, adding `_fire_callbacks` after updating the lock status allows it to propagate changes to HA entity faster.