### PR TITLE
Fix lock being detected as a blind tilt

### DIFF
--- a/switchbot/adv_parser.py
+++ b/switchbot/adv_parser.py
@@ -132,7 +132,6 @@ SUPPORTED_TYPES: dict[str, SwitchbotSupportedType] = {
         "modelFriendlyName": "Blind Tilt",
         "func": process_woblindtilt,
         "manufacturer_id": 2409,
-        "manufacturer_data_length": 10,
     },
 }
 


### PR DESCRIPTION
Since the lock and blind tilt have the same length we would make the wrong guess with passive only scans

fixes https://github.com/home-assistant/core/issues/90090