### PR TITLE
Make the Blind Tilt a sequence device

### DIFF
--- a/switchbot/adv_parsers/blind_tilt.py
+++ b/switchbot/adv_parsers/blind_tilt.py
@@ -23,4 +23,5 @@ def process_woblindtilt(
         "inMotion": _in_motion,
         "tilt": (100 - _tilt) if reverse else _tilt,
         "lightLevel": _light_level,
+        "sequence_number": device_data[0]
     }

--- a/switchbot/devices/blind_tilt.py
+++ b/switchbot/devices/blind_tilt.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from switchbot.devices.device import REQ_HEADER, update_after_operation
+from switchbot.devices.device import REQ_HEADER, update_after_operation, SwitchbotSequenceDevice
 
 from .curtain import CURTAIN_EXT_SUM_KEY, SwitchbotCurtain
 
@@ -26,7 +26,7 @@ CLOSE_UP_KEYS = [
 ]
 
 
-class SwitchbotBlindTilt(SwitchbotCurtain):
+class SwitchbotBlindTilt(SwitchbotCurtain, SwitchbotSequenceDevice):
     """Representation of a Switchbot Blind Tilt."""
 
     # The position of the blind is saved returned with 0 = closed down, 50 = open and 100 = closed up.


### PR DESCRIPTION
The blind tilt device includes a sequence number within it's advertisment data packet. This can be used to detect when there are changes to the basic info, as implemented by the SwitchbotSequenceDevice base class.

This PR adds the sequence number to the adv_parser output and updates the blind tilt class to also extend the sequence device base class.

I've made this change as I found the blind tilt devices integrated into home assistant got stuck in the opening/closing state. The data from the basic info is being used to detect motion, but that only gets updated when an action is triggered, or the 24 hour passive polling time has passed. This change means that the basic info will be queried after a change is seen in the advertisment data packet and the correct motion details can be reflected in home assistant.