### PR TITLE
Support Curtain 3

### DIFF
--- a/switchbot/adv_parser.py
+++ b/switchbot/adv_parser.py
@@ -77,6 +77,12 @@ SUPPORTED_TYPES: dict[str, SwitchbotSupportedType] = {
         "func": process_wocurtain,
         "manufacturer_id": 2409,
     },
+    "{": {
+        "modelName": SwitchbotModel.CURTAIN,
+        "modelFriendlyName": "Curtain 3",
+        "func": process_wocurtain,
+        "manufacturer_id": 2409,
+    },
     "w": {
         "modelName": SwitchbotModel.IO_METER,
         "modelFriendlyName": "Indoor/Outdoor Meter",

--- a/switchbot/adv_parser.py
+++ b/switchbot/adv_parser.py
@@ -71,15 +71,15 @@ SUPPORTED_TYPES: dict[str, SwitchbotSupportedType] = {
         "manufacturer_id": 2409,
         "manufacturer_data_length": 16,
     },
-    "c": {
-        "modelName": SwitchbotModel.CURTAIN,
-        "modelFriendlyName": "Curtain",
-        "func": process_wocurtain,
-        "manufacturer_id": 2409,
-    },
     "{": {
         "modelName": SwitchbotModel.CURTAIN,
         "modelFriendlyName": "Curtain 3",
+        "func": process_wocurtain,
+        "manufacturer_id": 2409,
+    },
+    "c": {
+        "modelName": SwitchbotModel.CURTAIN,
+        "modelFriendlyName": "Curtain",
         "func": process_wocurtain,
         "manufacturer_id": 2409,
     },

--- a/switchbot/adv_parsers/curtain.py
+++ b/switchbot/adv_parsers/curtain.py
@@ -6,10 +6,15 @@ def process_wocurtain(
     data: bytes | None, mfr_data: bytes | None, reverse: bool = True
 ) -> dict[str, bool | int]:
     """Process woCurtain/Curtain services data."""
-    if mfr_data and len(mfr_data) >= 11:
+    if mfr_data and len(mfr_data) >= 12: # Curtain 3
         device_data = mfr_data[8:11]
+        battery_data = mfr_data[12]
+    elif mfr_data and len(mfr_data) >= 11:
+        device_data = mfr_data[8:11]
+        battery_data = data[2] if data else None
     elif data:
         device_data = data[3:6]
+        battery_data = data[2]
     else:
         return {}
 
@@ -20,7 +25,7 @@ def process_wocurtain(
 
     return {
         "calibration": bool(data[1] & 0b01000000) if data else None,
-        "battery": data[2] & 0b01111111 if data else None,
+        "battery": battery_data & 0b01111111 if battery_data is not None else None,
         "inMotion": _in_motion,
         "position": (100 - _position) if reverse else _position,
         "lightLevel": _light_level,

--- a/switchbot/discovery.py
+++ b/switchbot/discovery.py
@@ -93,7 +93,9 @@ class GetSwitchbotDevices:
         """Return all WoCurtain/Curtains devices with services data."""
         regular_curtains = await self._get_devices_by_model("c")
         pairing_curtains = await self._get_devices_by_model("C")
-        return {**regular_curtains, **pairing_curtains}
+        regular_curtains3 = await self._get_devices_by_model("{")
+        pairing_curtains3 = await self._get_devices_by_model("[")
+        return {**regular_curtains, **pairing_curtains, **regular_curtains3, **pairing_curtains3}
 
     async def get_bots(self) -> dict[str, SwitchBotAdvertisement]:
         """Return all WoHand/Bot devices with services data."""

--- a/tests/test_adv_parser.py
+++ b/tests/test_adv_parser.py
@@ -322,6 +322,71 @@ def test_parse_advertisement_data_curtain_fully_open():
     )
 
 
+def test_parse_advertisement_data_curtain3():
+    """Test parse_advertisement_data for curtain 3."""
+    ble_device = generate_ble_device("aa:bb:cc:dd:ee:ff", "any")
+    adv_data = generate_advertisement_data(
+        manufacturer_data={2409: b"\xaa\xbb\xcc\xdd\xee\xff\xf7\x07\x00\x11\x04\x00\x49"},
+        service_data={"0000fd3d-0000-1000-8000-00805f9b34fb": b"{\xc0\x49\x00\x11\x04"},
+        rssi=-80,
+    )
+
+    result = parse_advertisement_data(ble_device, adv_data)
+    assert result == SwitchBotAdvertisement(
+        address="aa:bb:cc:dd:ee:ff",
+        data={
+            "rawAdvData": b"{\xc0\x49\x00\x11\x04",
+            "data": {
+                "calibration": True,
+                "battery": 73,
+                "inMotion": False,
+                "position": 100,
+                "lightLevel": 1,
+                "deviceChain": 1,
+            },
+            "isEncrypted": False,
+            "model": "{",
+            "modelFriendlyName": "Curtain 3",
+            "modelName": SwitchbotModel.CURTAIN,
+        },
+        device=ble_device,
+        rssi=-80,
+        active=True,
+    )
+
+
+def test_parse_advertisement_data_curtain3_passive():
+    """Test parse_advertisement_data for curtain passive."""
+    ble_device = generate_ble_device("aa:bb:cc:dd:ee:ff", "any")
+    adv_data = generate_advertisement_data(
+        manufacturer_data={2409: b"\xaa\xbb\xcc\xdd\xee\xff\xf7\x07\x00\x11\x04\x00\x49"},
+        service_data={},
+        rssi=-80,
+    )
+    result = parse_advertisement_data(ble_device, adv_data, SwitchbotModel.CURTAIN)
+    assert result == SwitchBotAdvertisement(
+        address="aa:bb:cc:dd:ee:ff",
+        data={
+            "rawAdvData": None,
+            "data": {
+                "calibration": None,
+                "battery": 73,
+                "inMotion": False,
+                "position": 100,
+                "lightLevel": 1,
+                "deviceChain": 1,
+            },
+            "isEncrypted": False,
+            "model": "c",
+            "modelFriendlyName": "Curtain",
+            "modelName": SwitchbotModel.CURTAIN,
+        },
+        device=ble_device,
+        rssi=-80,
+        active=False,
+    )
+
+
 def test_parse_advertisement_data_contact():
     """Test parse_advertisement_data for the contact sensor."""
     ble_device = generate_ble_device("aa:bb:cc:dd:ee:ff", "any")


### PR DESCRIPTION
Adds Curtain 3 support. Fixes home-assistant/core#99105.

It has a new model character (`{`/`[`), but otherwise seems to work with the existing code. It also includes battery level in manufacturer data. I'm not sure if that's specific to Curtain 3, or firmware 0.7.

In passive mode, Curtain 3 gets detected as a contact sensor because it has the same manufacturer data length. I couldn't figure out how to distinguish between them (and I don't have any contact sensors to investigate further).

<details>
<summary>Here are some manufacturer data values I recorded during testing.</summary>

```
byte 0 counter?
byte 1 ?
byte 2 position
byte 3 light level, device chain
byte 4 ?
byte 5 00
byte 6 battery

dc-xx-xx-xx-xx-xx-e5-03-00-11-03-00-56
ed-xx-xx-xx-xx-xx-a6-03-00-11-04-00-4b
d2-xx-xx-xx-xx-xx-cb-03-63-11-04-00-57
ed-xx-xx-xx-xx-xx-c4-03-b0-11-04-00-4b opening
ed-xx-xx-xx-xx-xx-c5-03-ad-11-04-00-4b opening
ed-xx-xx-xx-xx-xx-c6-03-aa-11-04-00-4b opening
ed-xx-xx-xx-xx-xx-c7-03-a8-11-04-00-4b opening
ed-xx-xx-xx-xx-xx-ce-03-19-11-04-00-4b stopped
ed-xx-xx-xx-xx-xx-da-03-00-11-04-00-4b stopped at open
ed-xx-xx-xx-xx-xx-e5-03-00-11-04-00-4b stopped at open
ed-xx-xx-xx-xx-xx-0f-03-64-11-04-00-4b stopped at closed
ed-xx-xx-xx-xx-xx-10-07-e4-11-04-00-4a opening
ed-xx-xx-xx-xx-xx-11-07-e3-11-04-00-4a opening
ed-xx-xx-xx-xx-xx-12-07-e1-11-04-00-4a opening
ed-xx-xx-xx-xx-xx-13-07-de-11-04-00-4a opening
ed-xx-xx-xx-xx-xx-19-07-ce-11-04-00-4a opening then stopped
ed-xx-xx-xx-xx-xx-1a-07-cb-11-04-00-4a opening then stopped
ed-xx-xx-xx-xx-xx-1d-07-48-11-05-00-4a opening then stopped
ed-xx-xx-xx-xx-xx-20-07-cd-11-05-00-4a closing then stopped
ed-xx-xx-xx-xx-xx-21-07-d0-11-05-00-4a closing then stopped
ed-xx-xx-xx-xx-xx-23-07-51-11-05-00-4a stopped
ed-xx-xx-xx-xx-xx-2c-07-64-11-04-00-4a stopped at closed
ed-xx-xx-xx-xx-xx-32-07-d8-11-04-00-4a opening
ed-xx-xx-xx-xx-xx-35-07-d0-11-04-00-4a opening
ed-xx-xx-xx-xx-xx-55-07-00-11-04-00-4a stopped at open
ed-xx-xx-xx-xx-xx-55-07-00-11-04-00-4a stopped at open again
```
</details>