### PR TITLE
Remove passive detection of contact sensors

### DIFF
--- a/switchbot/adv_parser.py
+++ b/switchbot/adv_parser.py
@@ -49,7 +49,6 @@ SUPPORTED_TYPES: dict[str, SwitchbotSupportedType] = {
         "modelFriendlyName": "Contact Sensor",
         "func": process_wocontact,
         "manufacturer_id": 2409,
-        "manufacturer_data_length": 13,
     },
     "H": {
         "modelName": SwitchbotModel.BOT,

--- a/tests/test_adv_parser.py
+++ b/tests/test_adv_parser.py
@@ -593,28 +593,10 @@ def test_contact_sensor_mfr_no_service_data():
         rssi=-70,
     )
     result = parse_advertisement_data(ble_device, adv_data)
-    assert result == SwitchBotAdvertisement(
-        address="aa:bb:cc:dd:ee:ff",
-        data={
-            "data": {
-                "battery": None,
-                "button_count": 4,
-                "contact_open": True,
-                "contact_timeout": True,
-                "is_light": False,
-                "motion_detected": False,
-                "tested": None,
-            },
-            "isEncrypted": False,
-            "model": "d",
-            "modelFriendlyName": "Contact Sensor",
-            "modelName": SwitchbotModel.CONTACT_SENSOR,
-            "rawAdvData": None,
-        },
-        device=ble_device,
-        rssi=-70,
-        active=False,
-    )
+    # Passive detection of contact sensor is not supported
+    # anymore since the Switchbot Curtain v3 was released
+    # which uses the heuristics for the contact sensor.
+    assert result is None
 
 
 def test_contact_sensor_srv():


### PR DESCRIPTION
We cannot tell these apart from the new Curtain v3 with only passive data so best not to be wrong about what the device is