### PR TITLE
Fix off-by-one error in curtain parser

### DIFF
--- a/switchbot/adv_parsers/curtain.py
+++ b/switchbot/adv_parsers/curtain.py
@@ -6,7 +6,7 @@ def process_wocurtain(
     data: bytes | None, mfr_data: bytes | None, reverse: bool = True
 ) -> dict[str, bool | int]:
     """Process woCurtain/Curtain services data."""
-    if mfr_data and len(mfr_data) >= 12: # Curtain 3
+    if mfr_data and len(mfr_data) >= 13: # Curtain 3
         device_data = mfr_data[8:11]
         battery_data = mfr_data[12]
     elif mfr_data and len(mfr_data) >= 11:

--- a/tests/test_adv_parser.py
+++ b/tests/test_adv_parser.py
@@ -120,6 +120,38 @@ def test_parse_advertisement_data_curtain_passive():
     )
 
 
+def test_parse_advertisement_data_curtain_passive_12_bytes():
+    """Test parse_advertisement_data for curtain passive."""
+    ble_device = generate_ble_device("aa:bb:cc:dd:ee:ff", "any")
+    adv_data = generate_advertisement_data(
+        manufacturer_data={2409: b"\xe7\xabF\xac\x8f\x92|\x0f\x00\x11\x04\x00"},
+        service_data={},
+        rssi=-80,
+    )
+    result = parse_advertisement_data(ble_device, adv_data, SwitchbotModel.CURTAIN)
+    assert result == SwitchBotAdvertisement(
+        address="aa:bb:cc:dd:ee:ff",
+        data={
+            "rawAdvData": None,
+            "data": {
+                "calibration": None,
+                "battery": None,
+                "inMotion": False,
+                "position": 100,
+                "lightLevel": 1,
+                "deviceChain": 1,
+            },
+            "isEncrypted": False,
+            "model": "c",
+            "modelFriendlyName": "Curtain",
+            "modelName": SwitchbotModel.CURTAIN,
+        },
+        device=ble_device,
+        rssi=-80,
+        active=False,
+    )
+
+
 def test_parse_advertisement_data_curtain_position_zero():
     """Test parse_advertisement_data for curtain position zero."""
     ble_device = generate_ble_device("aa:bb:cc:dd:ee:ff", "any")


### PR DESCRIPTION
Fixes https://github.com/home-assistant/core/issues/101157.

Line 12 probably should be changed to `>= 12` too, but I wanted to keep the changes to a minimum so I don’t risk breaking anything else for HA 2023.10.