### PR TITLE
Add support for data with zero values from WoSensorTH

### DIFF
--- a/switchbot/adv_parsers/meter.py
+++ b/switchbot/adv_parsers/meter.py
@@ -28,7 +28,7 @@ def process_wosensorth(data: bytes | None, mfr_data: bytes | None) -> dict[str, 
     _temp_f = (_temp_f * 10) / 10
     humidity = temp_data[2] & 0b01111111
 
-    if _temp_c == -0.0 and humidity == 0 and battery == 0:
+    if _temp_c == 0 and humidity == 0 and battery == 0:
         return {}
 
     _wosensorth_data = {

--- a/switchbot/adv_parsers/meter.py
+++ b/switchbot/adv_parsers/meter.py
@@ -26,13 +26,17 @@ def process_wosensorth(data: bytes | None, mfr_data: bytes | None) -> dict[str, 
     )
     _temp_f = (_temp_c * 9 / 5) + 32
     _temp_f = (_temp_f * 10) / 10
+    humidity = temp_data[2] & 0b01111111
+
+    if _temp_c == -0.0 and humidity == 0 and battery == 0:
+        return {}
 
     _wosensorth_data = {
         # Data should be flat, but we keep the original structure for now
         "temp": {"c": _temp_c, "f": _temp_f},
         "temperature": _temp_c,
         "fahrenheit": bool(temp_data[2] & 0b10000000),
-        "humidity": temp_data[2] & 0b01111111,
+        "humidity": humidity,
         "battery": battery,
     }
 

--- a/tests/test_adv_parser.py
+++ b/tests/test_adv_parser.py
@@ -940,6 +940,29 @@ def test_wosensor_passive_only():
     )
 
 
+def test_wosensor_active_zero_data():
+    """Test parsing wosensor with active data but all values are zero."""
+    ble_device = generate_ble_device("aa:bb:cc:dd:ee:ff", "any")
+    adv_data = generate_advertisement_data(
+        manufacturer_data={},
+        service_data={"0000fd3d-0000-1000-8000-00805f9b34fb": b"T\x00\x00\x00\x00\x00"},
+        tx_power=-127,
+        rssi=-50,
+    )
+    result = parse_advertisement_data(ble_device, adv_data)
+    assert result == SwitchBotAdvertisement(
+        address="aa:bb:cc:dd:ee:ff",
+        data={
+            "data": {},
+            "isEncrypted": False,
+            "model": "T",
+            "rawAdvData": b"T\x00\x00\x00\x00\x00",
+        },
+        device=ble_device,
+        rssi=-50,
+        active=True,
+    )
+
 def test_woiosensor_passive_and_active():
     """Test parsing woiosensor as passive with active data as well."""
     ble_device = generate_ble_device("aa:bb:cc:dd:ee:ff", "any")


### PR DESCRIPTION
This PR is to support processing data with zero values from WoSensorTH. I have experienced that when the power supply is not stable, the meter would advertise zero values and its screen would be flashing. This PR is to ignore those zero values as if no data is received.

Test case is added for the above case.