### PR TITLE
Fix lock encryption key retrieval

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
+aiohttp>=3.9.5
 bleak>=0.17.0
 bleak-retry-connector>=2.9.0
 cryptography>=38.0.3
-requests>=2.28.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 bleak>=0.17.0
 bleak-retry-connector>=2.9.0
 cryptography>=38.0.3
-boto3>=1.20.24
 requests>=2.28.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
 pytest-asyncio
 pytest-cov
+aiohttp>=3.9.5
 bleak>=0.17.0
 bleak-retry-connector>=3.4.0
 cryptography>=38.0.3
-requests>=2.28.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,5 +3,4 @@ pytest-cov
 bleak>=0.17.0
 bleak-retry-connector>=3.4.0
 cryptography>=38.0.3
-boto3>=1.20.24
 requests>=2.28.1

--- a/setup.py
+++ b/setup.py
@@ -4,11 +4,11 @@ setup(
     name="PySwitchbot",
     packages=["switchbot", "switchbot.devices", "switchbot.adv_parsers"],
     install_requires=[
+        "aiohttp>=3.9.5",
         "bleak>=0.19.0",
         "bleak-retry-connector>=3.4.0",
         "cryptography>=39.0.0",
         "pyOpenSSL>=23.0.0",
-        "requests>=2.28.1",
     ],
     version="0.44.1",
     description="A library to communicate with Switchbot",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ setup(
         "bleak-retry-connector>=3.4.0",
         "cryptography>=39.0.0",
         "pyOpenSSL>=23.0.0",
-        "boto3>=1.20.24",
         "requests>=2.28.1",
     ],
     version="0.44.1",

--- a/switchbot/api_config.py
+++ b/switchbot/api_config.py
@@ -1,13 +1,6 @@
 # Those values have been obtained from the following files in SwitchBot Android app
 # That's how you can verify them yourself
 # /assets/switchbot_config.json
-# /res/raw/amplifyconfiguration.json
-# /res/raw/awsconfiguration.json
 
-SWITCHBOT_APP_API_BASE_URL = "https://l9ren7efdj.execute-api.us-east-1.amazonaws.com"
-SWITCHBOT_APP_COGNITO_POOL = {
-    "PoolId": "us-east-1_x1fixo5LC",
-    "AppClientId": "66r90hdllaj4nnlne4qna0muls",
-    "AppClientSecret": "1v3v7vfjsiggiupkeuqvsovg084e3msbefpj9rgh611u30uug6t8",
-    "Region": "us-east-1",
-}
+SWITCHBOT_APP_API_BASE_URL = "api.switchbot.net"
+SWITCHBOT_APP_CLIENT_ID = "5nnwmhmsa9xxskm14hd85lm9bm"

--- a/switchbot/const.py
+++ b/switchbot/const.py
@@ -10,6 +10,14 @@ DEFAULT_RETRY_TIMEOUT = 1
 DEFAULT_SCAN_TIMEOUT = 5
 
 
+class SwitchbotApiError(RuntimeError):
+    """Raised when API call fails.
+
+    This exception inherits from RuntimeError to avoid breaking existing code
+    but will be changed to Exception in a future release.
+    """
+
+
 class SwitchbotAuthenticationError(RuntimeError):
     """Raised when authentication fails.
 

--- a/switchbot/devices/lock.py
+++ b/switchbot/devices/lock.py
@@ -14,8 +14,8 @@ from ..api_config import SWITCHBOT_APP_API_BASE_URL, SWITCHBOT_APP_CLIENT_ID
 from ..const import (
     LockStatus,
     SwitchbotAccountConnectionError,
-    SwitchbotAuthenticationError,
     SwitchbotApiError,
+    SwitchbotAuthenticationError,
 )
 from .device import SwitchbotDevice, SwitchbotOperationError
 
@@ -93,7 +93,9 @@ class SwitchbotLock(SwitchbotDevice):
         )
 
         if result.status_code > 299:
-            raise SwitchbotApiError(f"Unexpected status code returned by SwitchBot API: {result.status_code}")
+            raise SwitchbotApiError(
+                f"Unexpected status code returned by SwitchBot API: {result.status_code}"
+            )
 
         response = json.loads(result.content)
         if response["statusCode"] != 100:
@@ -109,21 +111,25 @@ class SwitchbotLock(SwitchbotDevice):
         device_mac = device_mac.replace(":", "").replace("-", "").upper()
 
         try:
-            auth_result = SwitchbotLock.api_request("account", "account/api/v1/user/login", {
-                "clientId": SWITCHBOT_APP_CLIENT_ID,
-                "username": username,
-                "password": password,
-                "grantType": "password",
-                "verifyCode": ""
-            })
+            auth_result = SwitchbotLock.api_request(
+                "account",
+                "account/api/v1/user/login",
+                {
+                    "clientId": SWITCHBOT_APP_CLIENT_ID,
+                    "username": username,
+                    "password": password,
+                    "grantType": "password",
+                    "verifyCode": "",
+                },
+            )
             auth_headers = {"authorization": auth_result["access_token"]}
         except Exception as err:
-            raise SwitchbotAuthenticationError(
-                f"Authentication failed: {err}"
-            ) from err
+            raise SwitchbotAuthenticationError(f"Authentication failed: {err}") from err
 
         try:
-            userinfo = SwitchbotLock.api_request("account", "account/api/v1/user/userinfo", {}, auth_headers)
+            userinfo = SwitchbotLock.api_request(
+                "account", "account/api/v1/user/userinfo", {}, auth_headers
+            )
             region = userinfo["botRegion"]
         except Exception as err:
             raise SwitchbotAccountConnectionError(
@@ -131,10 +137,15 @@ class SwitchbotLock(SwitchbotDevice):
             ) from err
 
         try:
-            device_info = SwitchbotLock.api_request(f"wonderlabs.{region}", "wonder/keys/v1/communicate", {
-                "device_mac": device_mac,
-                "keyType": "user",
-            }, auth_headers)
+            device_info = SwitchbotLock.api_request(
+                f"wonderlabs.{region}",
+                "wonder/keys/v1/communicate",
+                {
+                    "device_mac": device_mac,
+                    "keyType": "user",
+                },
+                auth_headers,
+            )
 
             return {
                 "key_id": device_info["communicationKey"]["keyId"],

--- a/switchbot/devices/lock.py
+++ b/switchbot/devices/lock.py
@@ -1,24 +1,21 @@
 """Library to handle connection with Switchbot Lock."""
 from __future__ import annotations
 
-import base64
-import hashlib
-import hmac
 import json
 import logging
 import time
 from typing import Any
 
-import boto3
 import requests
 from bleak.backends.device import BLEDevice
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
-from ..api_config import SWITCHBOT_APP_API_BASE_URL, SWITCHBOT_APP_COGNITO_POOL
+from ..api_config import SWITCHBOT_APP_API_BASE_URL, SWITCHBOT_APP_CLIENT_ID
 from ..const import (
     LockStatus,
     SwitchbotAccountConnectionError,
     SwitchbotAuthenticationError,
+    SwitchbotApiError,
 )
 from .device import SwitchbotDevice, SwitchbotOperationError
 
@@ -87,76 +84,66 @@ class SwitchbotLock(SwitchbotDevice):
         return lock_info is not None
 
     @staticmethod
+    def api_request(subdomain: str, path: str, data: dict, headers: dict = None):
+        result = requests.post(
+            url=f"https://{subdomain}.{SWITCHBOT_APP_API_BASE_URL}/{path}",
+            headers=headers,
+            json=data,
+            timeout=5,
+        )
+
+        if result.status_code > 299:
+            raise SwitchbotApiError(f"Unexpected status code returned by SwitchBot API: {result.status_code}")
+
+        response = json.loads(result.content)
+        if response["statusCode"] != 100:
+            raise SwitchbotApiError(
+                f"{response['message']}, status code: {response['statusCode']}"
+            )
+
+        return response["body"]
+
+    @staticmethod
     def retrieve_encryption_key(device_mac: str, username: str, password: str):
         """Retrieve lock key from internal SwitchBot API."""
         device_mac = device_mac.replace(":", "").replace("-", "").upper()
-        msg = bytes(username + SWITCHBOT_APP_COGNITO_POOL["AppClientId"], "utf-8")
-        secret_hash = base64.b64encode(
-            hmac.new(
-                SWITCHBOT_APP_COGNITO_POOL["AppClientSecret"].encode(),
-                msg,
-                digestmod=hashlib.sha256,
-            ).digest()
-        ).decode()
 
-        cognito_idp_client = boto3.client(
-            "cognito-idp", region_name=SWITCHBOT_APP_COGNITO_POOL["Region"]
-        )
         try:
-            auth_response = cognito_idp_client.initiate_auth(
-                ClientId=SWITCHBOT_APP_COGNITO_POOL["AppClientId"],
-                AuthFlow="USER_PASSWORD_AUTH",
-                AuthParameters={
-                    "USERNAME": username,
-                    "PASSWORD": password,
-                    "SECRET_HASH": secret_hash,
-                },
-            )
-        except cognito_idp_client.exceptions.NotAuthorizedException as err:
-            raise SwitchbotAuthenticationError(
-                f"Failed to authenticate: {err}"
-            ) from err
+            auth_result = SwitchbotLock.api_request("account", "account/api/v1/user/login", {
+                "clientId": SWITCHBOT_APP_CLIENT_ID,
+                "username": username,
+                "password": password,
+                "grantType": "password",
+                "verifyCode": ""
+            })
+            auth_headers = {"authorization": auth_result["access_token"]}
         except Exception as err:
             raise SwitchbotAuthenticationError(
-                f"Unexpected error during authentication: {err}"
+                f"Authentication failed: {err}"
             ) from err
 
-        if (
-            auth_response is None
-            or "AuthenticationResult" not in auth_response
-            or "AccessToken" not in auth_response["AuthenticationResult"]
-        ):
-            raise SwitchbotAuthenticationError("Unexpected authentication response")
-
-        access_token = auth_response["AuthenticationResult"]["AccessToken"]
         try:
-            key_response = requests.post(
-                url=SWITCHBOT_APP_API_BASE_URL + "/developStage/keys/v1/communicate",
-                headers={"authorization": access_token},
-                json={
-                    "device_mac": device_mac,
-                    "keyType": "user",
-                },
-                timeout=10,
-            )
-        except requests.exceptions.RequestException as err:
+            userinfo = SwitchbotLock.api_request("account", "account/api/v1/user/userinfo", {}, auth_headers)
+            region = userinfo["botRegion"]
+        except Exception as err:
+            raise SwitchbotAccountConnectionError(
+                f"Failed to retrieve SwitchBot Account user details: {err}"
+            ) from err
+
+        try:
+            device_info = SwitchbotLock.api_request(f"wonderlabs.{region}", "wonder/keys/v1/communicate", {
+                "device_mac": device_mac,
+                "keyType": "user",
+            }, auth_headers)
+
+            return {
+                "key_id": device_info["communicationKey"]["keyId"],
+                "encryption_key": device_info["communicationKey"]["key"],
+            }
+        except Exception as err:
             raise SwitchbotAccountConnectionError(
                 f"Failed to retrieve encryption key from SwitchBot Account: {err}"
             ) from err
-        if key_response.status_code > 299:
-            raise SwitchbotAuthenticationError(
-                f"Unexpected status code returned by SwitchBot Account API: {key_response.status_code}"
-            )
-        key_response_content = json.loads(key_response.content)
-        if key_response_content["statusCode"] != 100:
-            raise SwitchbotAuthenticationError(
-                f"Unexpected status code returned by SwitchBot API: {key_response_content['statusCode']}"
-            )
-
-        return {
-            "key_id": key_response_content["body"]["communicationKey"]["keyId"],
-            "encryption_key": key_response_content["body"]["communicationKey"]["key"],
-        }
 
     async def lock(self) -> bool:
         """Send lock command."""

--- a/switchbot/devices/lock.py
+++ b/switchbot/devices/lock.py
@@ -1,12 +1,12 @@
 """Library to handle connection with Switchbot Lock."""
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from typing import Any
 
 import aiohttp
-import asyncio
 from bleak.backends.device import BLEDevice
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
@@ -85,7 +85,11 @@ class SwitchbotLock(SwitchbotDevice):
 
     @staticmethod
     async def api_request(
-            session: aiohttp.ClientSession, subdomain: str, path: str, data: dict = None, headers: dict = None
+        session: aiohttp.ClientSession,
+        subdomain: str,
+        path: str,
+        data: dict = None,
+        headers: dict = None,
     ) -> dict:
         url = f"https://{subdomain}.{SWITCHBOT_APP_API_BASE_URL}/{path}"
         async with session.post(url, json=data, headers=headers) as result:
@@ -107,12 +111,15 @@ class SwitchbotLock(SwitchbotDevice):
     def retrieve_encryption_key(device_mac: str, username: str, password: str):
         async def async_fn():
             async with aiohttp.ClientSession() as session:
-                return await SwitchbotLock.async_retrieve_encryption_key(session, device_mac, username, password)
+                return await SwitchbotLock.async_retrieve_encryption_key(
+                    session, device_mac, username, password
+                )
+
         return asyncio.run(async_fn())
 
     @staticmethod
     async def async_retrieve_encryption_key(
-            session: aiohttp.ClientSession, device_mac: str, username: str, password: str
+        session: aiohttp.ClientSession, device_mac: str, username: str, password: str
     ) -> dict:
         """Retrieve lock key from internal SwitchBot API."""
         device_mac = device_mac.replace(":", "").replace("-", "").upper()

--- a/switchbot/devices/lock.py
+++ b/switchbot/devices/lock.py
@@ -130,7 +130,10 @@ class SwitchbotLock(SwitchbotDevice):
             userinfo = SwitchbotLock.api_request(
                 "account", "account/api/v1/user/userinfo", {}, auth_headers
             )
-            region = userinfo["botRegion"]
+            if "botRegion" in userinfo and userinfo["botRegion"] != "":
+                region = userinfo["botRegion"]
+            else:
+                region = "us"
         except Exception as err:
             raise SwitchbotAccountConnectionError(
                 f"Failed to retrieve SwitchBot Account user details: {err}"


### PR DESCRIPTION
It seems that SwitchBot has made some changes to their accounts and the previous key retrieval method doesn't work for everybody. This is based on @alexschultze and @hsakoh research, and verified myself with the SwitchBot Android application code.
Since cognito authentication is no longer used I also removed the boto3 dependency.

Fixes #234

Edit: I noticed only after creating this PR that there already is one addressing the exact same issue #235