### PR TITLE
possible night latch fix - lock pro

### DIFF
--- a/switchbot/adv_parsers/lock.py
+++ b/switchbot/adv_parsers/lock.py
@@ -49,7 +49,7 @@ def process_wolock_pro(
         "unclosed_alarm": bool(mfr_data[11] & 0b10000000),
         "unlocked_alarm": bool(mfr_data[11] & 0b01000000),
         "auto_lock_paused": bool(mfr_data[8] & 0b100000),
-        "night_latch": bool(mfr_data[9] & 0b00000001),
+        "night_latch": bool(mfr_data[9] & 0b00010000),
     }
     _LOGGER.debug(res)
     return res


### PR DESCRIPTION
After analyzing publicly posted lock pro adv data. I think I found the right bit indicating night latch.
But this needs to be tested by someone who actually have lock pro.

update pySwitchbot library in HomeAssistent from my fork
`pip install --upgrade --no-deps --force-reinstall git+https://github.com/Michal4K/pySwitchbot@night_latch_lock_pro`

**Do not forget --no-deps**, unless you want broke up your HA dependencies.
Then restart HA and reload switchbot integration.

So anyone feel free to test this and report back.