### PR TITLE
disable detection of night latch for lock pro

### DIFF
--- a/switchbot/adv_parsers/lock.py
+++ b/switchbot/adv_parsers/lock.py
@@ -49,7 +49,8 @@ def process_wolock_pro(
         "unclosed_alarm": bool(mfr_data[11] & 0b10000000),
         "unlocked_alarm": bool(mfr_data[11] & 0b01000000),
         "auto_lock_paused": bool(mfr_data[8] & 0b100000),
-        "night_latch": bool(mfr_data[9] & 0b00000001),
+        # Looks like night latch bit is not anymore in ADV 
+        "night_latch": False,
     }
     _LOGGER.debug(res)
     return res

--- a/switchbot/adv_parsers/lock.py
+++ b/switchbot/adv_parsers/lock.py
@@ -49,7 +49,7 @@ def process_wolock_pro(
         "unclosed_alarm": bool(mfr_data[11] & 0b10000000),
         "unlocked_alarm": bool(mfr_data[11] & 0b01000000),
         "auto_lock_paused": bool(mfr_data[8] & 0b100000),
-        # Looks like night latch bit is not anymore in ADV 
+        # Looks like night latch bit is not anymore in ADV
         "night_latch": False,
     }
     _LOGGER.debug(res)

--- a/tests/test_adv_parser.py
+++ b/tests/test_adv_parser.py
@@ -1459,6 +1459,39 @@ def test_parsing_lock_pro_passive():
     )
 
 
+def test_parsing_lock_pro_passive_nightlatch_disabled():
+    ble_device = generate_ble_device("aa:bb:cc:dd:ee:ff", "any")
+    adv_data = generate_advertisement_data(
+        manufacturer_data={2409: bytes.fromhex("aabbccddeeff0a8200630000")}, rssi=-67
+    )
+    result = parse_advertisement_data(ble_device, adv_data, SwitchbotModel.LOCK_PRO)
+    assert result == SwitchBotAdvertisement(
+        address="aa:bb:cc:dd:ee:ff",
+        data={
+            "data": {
+                "battery": None,
+                "calibration": True,
+                "status": LockStatus.LOCKED,
+                "update_from_secondary_lock": False,
+                "door_open": False,
+                "double_lock_mode": False,
+                "unclosed_alarm": False,
+                "unlocked_alarm": False,
+                "auto_lock_paused": False,
+                "night_latch": False,
+            },
+            "model": "$",
+            "isEncrypted": False,
+            "modelFriendlyName": "Lock Pro",
+            "modelName": SwitchbotModel.LOCK_PRO,
+            "rawAdvData": None,
+        },
+        device=ble_device,
+        rssi=-67,
+        active=False,
+    )
+
+
 def test_parsing_lock_active_old_firmware():
     """Test parsing lock with active data. Old firmware."""
     ble_device = generate_ble_device("aa:bb:cc:dd:ee:ff", "any")


### PR DESCRIPTION
We should just disable this. It looks like night latch bit is not anymore in Lock Pro ADV.
Discussed in this draft: https://github.com/Danielhiversen/pySwitchbot/pull/245

For Home Assistant i create a little work around to force lock to be setup as if night latch is detected.
https://github.com/home-assistant/core/pull/124326#issue-2476424411

I don't believe OpenWonderLabs will publish documentation, which would help with correct implementation anytime soon.