### PR TITLE
Fix Meter Pro being detected as a light strip without active scans

### DIFF
--- a/switchbot/adv_parser.py
+++ b/switchbot/adv_parser.py
@@ -69,7 +69,6 @@ SUPPORTED_TYPES: dict[str, SwitchbotSupportedType] = {
         "modelFriendlyName": "Light Strip",
         "func": process_wostrip,
         "manufacturer_id": 2409,
-        "manufacturer_data_length": 16,
     },
     "{": {
         "modelName": SwitchbotModel.CURTAIN,

--- a/tests/test_adv_parser.py
+++ b/tests/test_adv_parser.py
@@ -807,43 +807,6 @@ def test_bulb_active():
     )
 
 
-def test_lightstrip_passive():
-    """Test parsing lightstrip as passive."""
-    ble_device = generate_ble_device("aa:bb:cc:dd:ee:ff", "any")
-    adv_data = generate_advertisement_data(
-        manufacturer_data={
-            2409: b"`U\xf9(\xe5\x96\x00d\x02\xb0\x00\x00\x00\x00\x00\x00"
-        },
-        service_data={},
-        tx_power=-127,
-        rssi=-50,
-    )
-    result = parse_advertisement_data(ble_device, adv_data)
-    assert result == SwitchBotAdvertisement(
-        address="aa:bb:cc:dd:ee:ff",
-        data={
-            "data": {
-                "brightness": 100,
-                "color_mode": 2,
-                "delay": False,
-                "isOn": False,
-                "loop_index": 0,
-                "preset": False,
-                "sequence_number": 0,
-                "speed": 48,
-            },
-            "isEncrypted": False,
-            "model": "r",
-            "modelFriendlyName": "Light Strip",
-            "modelName": SwitchbotModel.LIGHT_STRIP,
-            "rawAdvData": None,
-        },
-        device=ble_device,
-        rssi=-50,
-        active=False,
-    )
-
-
 def test_wosensor_passive_and_active():
     """Test parsing wosensor as passive with active data as well."""
     ble_device = generate_ble_device("aa:bb:cc:dd:ee:ff", "any")


### PR DESCRIPTION
This means we can't tell the difference between light strips and meter pros because they have the same length so we need to drop passive detection of light strips.

fixes #264